### PR TITLE
Allow 'unknown' as a platform on rescues.

### DIFF
--- a/api/models/rescue.js
+++ b/api/models/rescue.js
@@ -75,10 +75,11 @@ RescueSchema = new Schema({
     type: String
   },
   platform: {
-    default: 'pc',
+    default: 'unknown',
     enum: [
       'pc',
-      'xb'
+      'xb',
+      'unknown'
     ],
     type: String
   },


### PR DESCRIPTION
Allow 'unknown' as a platform and make it the new default.

This is to properly allow for cases where we haven't explicitly set a client's platform.  While we generally assume it to be PC in this instance, we shouldn't explicitly say it is.

Closes #52 