### PR TITLE
Use a not equal comparison instead of false for checking that rescue …

### DIFF
--- a/api/classes/Statistics.js
+++ b/api/classes/Statistics.js
@@ -13,7 +13,9 @@ class Statistics {
         open: false,
         data: {
           markedForDeletion: {
-            marked: false
+            marked: {
+              $ne: true
+            }
           }
         }
       },


### PR DESCRIPTION
…is not MD’ed to support legacy cases