### PR TITLE
Call authentication directly within the try-catch instead of register…

### DIFF
--- a/api/controllers/auth.js
+++ b/api/controllers/auth.js
@@ -94,7 +94,7 @@ class Authentication {
     return false
   }
 
-  static async authenticate (ctx, next) {
+  static async authenticate (ctx) {
     let [ clientId, clientSecret ] = getBasicAuth(ctx)
     if (clientId) {
       ctx.state.client = await Authentication.clientAuthenticate(clientId, clientSecret)
@@ -105,7 +105,7 @@ class Authentication {
       let user = await User.scope('internal').findOne({where: { id: ctx.session.userId }})
       if (user) {
         ctx.state.user = UsersPresenter.render(user, {})
-        return next()
+        return true
       }
     }
 
@@ -115,12 +115,12 @@ class Authentication {
       if (bearerCheck) {
         ctx.state.user = bearerCheck.user
         ctx.state.scope = bearerCheck.scope
-        return next()
+        return true
       } else {
         throw Error.template('not_authenticated')
       }
     }
-    await next()
+    return false
   }
 
   static isAuthenticated (ctx, next) {

--- a/index.js
+++ b/index.js
@@ -100,12 +100,12 @@ app.use(async function (ctx, next) {
   await next()
 })
 
-app.use(Authentication.authenticate)
-
 const traffic = new TrafficControl()
 
 app.use(async (ctx, next) => {
   try {
+    await Authentication.authenticate(ctx)
+
     let rateLimit = traffic.validateRateLimit(ctx)
 
     ctx.set('X-API-Version', '2.0')


### PR DESCRIPTION
…ing it as a middleware so errors are handed back to the client