### PR TITLE
fix race condition with db.sync()

### DIFF
--- a/api/db/index.js
+++ b/api/db/index.js
@@ -17,8 +17,6 @@ let db = new Sequelize(config.postgres.database, config.postgres.username, confi
   }
 })
 
-//db.sync()
-
 let models = {
   db
 }

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -17,8 +17,6 @@ let db = new Sequelize(config.postgres.database, config.postgres.username, confi
   }
 })
 
-// we should be exposing db.sync() so the app can wait for
-// the DB to be ready before listening
 //db.sync()
 
 let models = {

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -17,7 +17,9 @@ let db = new Sequelize(config.postgres.database, config.postgres.username, confi
   }
 })
 
-db.sync()
+// we should be exposing db.sync() so the app can wait for
+// the DB to be ready before listening
+//db.sync()
 
 let models = {
   db

--- a/index.js
+++ b/index.js
@@ -332,16 +332,6 @@ wss.on('connection', async function connection (client) {
   })
 })
 
-// only listen once the DB is sync'd
-db.sync().then( () => {
-  server.listen(port, config.hostname, (error) => {
-    if (error) {
-  
-    }
-    logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
-  })
-}).catch(logger.error)
-
 function censor (obj) {
   let censoredObj = {}
   Object.assign(censoredObj, obj)
@@ -378,3 +368,17 @@ function clean (...cleanFields) {
     await next()
   }
 }
+
+(async function startServer() {
+  try {
+    await db.sync()
+    server.listen(port, config.hostname, (error) => {
+      if (error) {
+        return logger.error(error)
+      }
+      logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
+    })
+  } catch(error) {
+    logger.error(error)
+  }
+})()

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const WebSocketManager = require('./api/websocket')
 const jiraDrill = require('./api/controllers/jira/drill')
 const { AnopeWebhook } = require('./api/controllers/anope-webhook')
 
+const db = require('./api/db').db
 
 try {
   npid.remove('api.pid')
@@ -331,12 +332,15 @@ wss.on('connection', async function connection (client) {
   })
 })
 
-server.listen(port, config.hostname, (error) => {
-  if (error) {
-
-  }
-  logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
-})
+// only listen once the DB is sync'd
+db.sync().then( () => {
+  server.listen(port, config.hostname, (error) => {
+    if (error) {
+  
+    }
+    logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
+  })
+}).catch(logger.error)
 
 function censor (obj) {
   let censoredObj = {}

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const http = require('http')
 const ws = require('ws')
 const { URL } = require('url')
 const logger = require('./api/logger')
+const { promisify } = require('util');
 
 const fs = require('fs')
 const Permission = require('./api/permission')
@@ -372,12 +373,9 @@ function clean (...cleanFields) {
 (async function startServer() {
   try {
     await db.sync()
-    server.listen(port, config.hostname, (error) => {
-      if (error) {
-        return logger.error(error)
-      }
-      logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
-    })
+    const listen = promisify(server.listen.bind(server))
+    await listen(port, config.hostname)
+    logger.info(`HTTP Server listening on ${config.hostname} port ${port}`)
   } catch(error) {
     logger.error(error)
   }


### PR DESCRIPTION
Hi there, 

I am a fairly new rat on PS4 and interested in the back-end stuff you have.  I noticed that the leaderboard appeared to be failing and decided to try and see if I could figure out the problem.

I figured the best way to start was to replicate the API service locally and I immediately found that the script bin/createTestUser.js was failing on my machine due to a race condition with db.sync() being executed twice.

I have made some very small changes that should hopefully prevent this and also ensure the DB is sync'd before the app starts listening.  Hopefully I'll get some time later this week and will work on a new script to create a test DB, similar to the bin/createTestUser.js script.

Cheers,
Scott