### PR TITLE
workaround open event handles at end of unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev": "$(npm bin)/grunt api",
-    "test": ""
+    "test": "node test/all.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,18 @@
+'use strict'
+
+process.env.NODE_ENV = 'testing'
+
+const { promisify } = require('util')
+
+const tests = ['v2']
+
+async function start () {
+
+  const reporter = require('nodeunit').reporters.default
+  const run = promisify(reporter.run)
+  await run(tests.map((t) => 'test/' + t), undefined)
+  process.exit(0)
+
+}
+
+start()


### PR DESCRIPTION
Banging my head trying to debug what event handler was keeping the process alive.  Decided to just workaround with a simple process.exit(0) at the end of the tests instead - less intrusive.  I'll revisit this later.