### PR TITLE
Unit tests and fix for rescue subquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ or even specify a single test withing the group:
 
     npm test login resetPassword
 
-When running the entire test suite, any ouput to stderr or stdout is muted to keep the build process clean.  If you run the tests individually, this output is restored to aid test development.
+When running the entire test suite or a test group, any ouput to stderr or stdout is muted to keep the build process clean.  If you run the tests individually, this output is restored to aid test development.
 
 ## License
 Copyright 2017 The Fuel Rats Mischief

--- a/api/Query/RescueQuery.js
+++ b/api/Query/RescueQuery.js
@@ -1,6 +1,7 @@
 'use strict'
 const { Rat, Epic } = require('./../db')
 const Query = require('./index')
+const { isEmpty } = require('underscore')
 
 /**
  * A class representing a rescue query
@@ -53,7 +54,7 @@ class RescueQuery extends Query {
         where: rats,
         model: Rat,
         as: 'rats',
-        required: false,
+        required: !isEmpty(rats),
         through: {
           attributes: []
         }
@@ -62,13 +63,13 @@ class RescueQuery extends Query {
         where: firstLimpet,
         model: Rat,
         as: 'firstLimpet',
-        required: false
+        required: !isEmpty(firstLimpet)
       },
       {
         where: epics,
         model: Epic,
         as: 'epics',
-        required: false
+        required: !isEmpty(epics)
       }
     ]
   }

--- a/api/classes/Request.js
+++ b/api/classes/Request.js
@@ -89,12 +89,10 @@ class Request {
         })
 
         response.on('end', function () {
-          resolve({
-            response,
-            // only try to parse the body if we actually recieved
-            // something to parse, otherwise let it though verbatim
-            body: body ? JSON.parse(body) : body
-          })
+          try {
+            body = JSON.parse(body)
+          } catch (ex) { /* failed to parse - send verbatim */ }
+          resolve({ response, body })
         })
       })
     })
@@ -141,17 +139,9 @@ class Request {
 
         response.on('end', function () {
           try {
-            let jsonBody = JSON.parse(body)
-            resolve({
-              response,
-              body: jsonBody
-            })
-          } catch (ex) {
-            resolve({
-              response,
-              body
-            })
-          }
+            body = JSON.parse(body)
+          } catch (ex) { /* failed to parse - send verbatim */ }
+          resolve({ response, body })
         })
       })
 
@@ -200,17 +190,9 @@ class Request {
 
         response.on('end', function () {
           try {
-            let jsonBody = JSON.parse(body)
-            resolve({
-              response,
-              body: jsonBody
-            })
-          } catch (ex) {
-            resolve({
-              response,
-              body
-            })
-          }
+            body = JSON.parse(body)
+          } catch (ex) { /* failed to parse - send verbatim */ }
+          resolve({ response, body })
         })
       })
 

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,11 @@ const options = {
   mute: true
 }
 
+process.on('unhandledRejection', err => {
+  error('unhandledRejection' + err.message + '\n' + err.stack)
+  process.exit(1)
+})
+
 /**
  * run against all the files/dirs defined in tests
  * @returns {Promise.<void>}

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,11 @@
 const fs = require('fs')
 const { promisify } = require('util')
 const { join } = require('path')
+const { error } = require('./support/mute')
 
 // we want to explicity run the test in order of complexity
 // not their alphabetical order 
 const defaultTests = ['login', 'user', 'rat', 'rescue', 'stats']
-
-const bwrite = process.stderr.write.bind(process.stderr)
 
 const START_OF_ARGS = 2
 const args = (process.ARGV || process.argv).slice(START_OF_ARGS)
@@ -35,9 +34,11 @@ async function start () {
     let tests
 
     if (args.length) {
-      // must have specified a specific test
+      // must have specified what we want to run
       tests = [ args.shift() ]
       options.testspec = args.shift()
+      // unmumte if we have specified a single test to run
+      options.mute = !options.testspec
     } else {
       // just run the default tests
       tests = defaultTests
@@ -54,8 +55,7 @@ async function start () {
       throw Error('cannot find test file: ' + file)
     }), options)
   } catch (err) {
-    // just in case we have failed to restore stderr
-    bwrite(err + '\n', 'utf8')
+    error(err)
   }
 
   process.exit(0)

--- a/test/rescue.js
+++ b/test/rescue.js
@@ -172,6 +172,7 @@ module.exports = {
 
     const adminUser = await auth.adminUserCookie()
     
+    await rescue.create(adminUser, {rats: ['kevin', 'clive']})
     const res = await rescue.create(adminUser, {client: 'damsel', platform: 'xb', system: 'sol', rats: ['roland']})
     test.notEqual(res.id, null)
 

--- a/test/rescue.js
+++ b/test/rescue.js
@@ -187,5 +187,39 @@ module.exports = {
       test.strictEqual(attr.platform, 'xb')
     }
 
+  }),
+  /**
+   * @api {get} /rescues Find rescue firstLimpet by rat name
+   * @apiName FindRescueFirstLimpetByRatName
+   * @apiGroup Rescue
+   * 
+   * @apiHeader {String} Cookie auth token
+   * 
+   * @apiExample
+   * GET /rescues?firstLimpet.name.ilike=roland HTTP/1.1
+   * Cookie: fuelrats:session=eyJ1c2VySWQiOiJiYTZmN2ViMy0zYzFjLTQ0MDktOWEwZS1iM2IwYjRjMzdjN2IiLCJfZXhwaXJlIjoxNTA5NDg0MDMwODg1LCJfbWF4QWdlIjo4NjQwMDAwMH0=; path=/; httponly;
+   */
+  rescueFindFirstLimpetByRatName: asyncWrap(async function (test) {
+
+    const NUM_TESTS = 6
+    test.expect(NUM_TESTS)
+
+    const adminUser = await auth.adminUserCookie()
+    
+    await rescue.create(adminUser, {rats: ['kevin', 'clive', 'roland'], firstLimpet: 'clive'})
+    const res = await rescue.create(adminUser, {client: 'damsel', platform: 'xb', system: 'sol', rats: ['kevin', 'roland'], firstLimpet: 'roland'})
+    test.notEqual(res.id, null)
+
+    const find = await get(adminUser, '/rescues?firstLimpet.name.ilike=roland')
+    test.strictEqual(find.response.statusCode, HTTP_OK)
+    if (find.body) {
+      let { data } = find.body
+      test.strictEqual(data.length, 1) // should have only one rescue returned
+      test.strictEqual(data[0].id, res.id)
+      const attr = data[0].attributes
+      test.strictEqual(attr.system, 'sol')
+      test.strictEqual(attr.platform, 'xb')
+    }
+
   })
 }

--- a/test/support/db.js
+++ b/test/support/db.js
@@ -6,7 +6,6 @@ if (process.env.NODE_ENV !== 'testing') {
 }
 
 const { db, User, Client, Group, Reset } = require('../../api/db')
-db.options.logging = false
 
 const group = {}
 

--- a/test/support/mute.js
+++ b/test/support/mute.js
@@ -3,7 +3,8 @@
 // remember where we parked
 const _stdout = process.stdout.write
 const _stderr = process.stdout.write
-const bwrite = process.stdout.write.bind(process.stdout)
+const boutwrite = process.stdout.write.bind(process.stdout)
+const berrwrite = process.stderr.write.bind(process.stderr)
 
 /**
  * 
@@ -41,9 +42,17 @@ function unmute () {
  * @param {*} msg 
  */
 function log (msg) {
-  bwrite(msg + '\n', 'utf8')
+  boutwrite(msg + '\n', 'utf8')
+}
+
+/**
+ * 
+ * @param {*} msg 
+ */
+function error (msg) {
+  berrwrite(msg + '\n', 'utf8')
 }
 
 module.exports = {
-  mute, unmute, log
+  mute, unmute, log, error
 }


### PR DESCRIPTION
Hi @xlexi - some tidying up, but also what I think is a fix for a subquery issue.  I noticed that using /rescues?rats.name=GeekyDeaks returned all rescues because the JOIN to Rats was LEFT OUTER.  My solution was to use the subquery to determine if the association was 'required'. Let me know if you think it should be handled differently.