### PR TITLE
Include received 'meta' field in response upon an error (API-246)

### DIFF
--- a/api/websocket.js
+++ b/api/websocket.js
@@ -127,7 +127,8 @@ class WebSocketManager {
       if (!error.code) {
         error = Error.template('server_error', error)
       }
-      this.send(client, error)
+
+      this.send(client, Object.assign({'meta': request.meta}, error))
     }
   }
 


### PR DESCRIPTION
Simple change, does what it says on the tin. I try to stay away from JavaScript, but I'd like to use this in Mecha 3 as soon as possible.
See [API-246](https://jira.fuelrats.com/browse/API-246)