### PR TITLE
Include received 'meta' field in response upon an error (API-246)

### DIFF
--- a/src/classes/WebSocket.js
+++ b/src/classes/WebSocket.js
@@ -106,7 +106,7 @@ export default class WebSocket {
       if ((error instanceof APIError) === false) {
         error = new InternalServerError({})
       }
-      this.send(client, Object.assign({"meta": request.meta}, error))
+      this.send(client, Object.assign({'meta': request.meta}, error))
     }
   }
 

--- a/src/classes/WebSocket.js
+++ b/src/classes/WebSocket.js
@@ -106,7 +106,7 @@ export default class WebSocket {
       if ((error instanceof APIError) === false) {
         error = new InternalServerError({})
       }
-      this.send(client, error)
+      this.send(client, Object.assign({"meta": request.meta}, error))
     }
   }
 


### PR DESCRIPTION
Round 2. I do test my code against `dev.api.fuelrats.com` and that is where I first noticed this. Sorry for the wrong PR. [API-246](https://jira.fuelrats.com/browse/API-246)