### PR TITLE
yolo

### DIFF
--- a/api/controllers/register.js
+++ b/api/controllers/register.js
@@ -80,7 +80,7 @@ class Register {
 
       let userQuery = new UserQuery({ id: user.id }, ctx)
       let result = await User.scope('public').findAndCountAll(userQuery.toSequelize)
-      await HostServ.update(user[0])
+      await HostServ.update(result[0])
       process.emit('registration', ctx, ctx.data)
 
       ctx.body = UserPresenter.render(result.rows, ctx.meta(result, userQuery))


### PR DESCRIPTION
Hostname set was being called with the wrong variable, causing an exception to be thrown and the entire transaction cancelled.