### PR TITLE
Fix an issue that was causing oauth2 ROPC requests to fail.

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ let port = config.port || process.env.PORT
 
 app.use(async function (ctx, next) {
   ctx.data = ctx.request.fields || {}
+  ctx.request.body = ctx.data
   ctx.meta = WebSocketManager.meta
   ctx.client = {}
 


### PR DESCRIPTION
The new body parser introduced to deal with stripe's webhooks places parsed json contents on a different field than the oauth library is expecting, this resolves that by copying the body contents to the old location