### PR TITLE
Fix issue exposing hashed secret keys

### DIFF
--- a/api/controllers/oauth2.js
+++ b/api/controllers/oauth2.js
@@ -142,7 +142,7 @@ class OAuth2 {
   static async authorizationRender (ctx, next) {
     let client = {}
     Object.assign(client, ctx.state.oauth2.client)
-    delete client.secret
+    delete client.data.attributes.secret
 
     ctx.body = {
       transactionId: ctx.state.oauth2.transactionID,


### PR DESCRIPTION
Fix an issue that was exposing the hashed version of an oauth application's secret key on loading authorize page