### PR TITLE
Api 318/paperwork revisions

### DIFF
--- a/src/Documents/Document.mjs
+++ b/src/Documents/Document.mjs
@@ -144,7 +144,10 @@ class Document {
       const singleObjectId = (new this.#type({ object: this.#objects })).id
       return `${config.server.externalUrl}/${this.#type.type}/${singleObjectId}`
     }
-    return `${config.server.externalUrl}/${this.#type.type}`
+    if (this.#type) {
+      return `${config.server.externalUrl}/${this.#type.type}`
+    }
+    return undefined
   }
 
   /**

--- a/src/db/Rescue.mjs
+++ b/src/db/Rescue.mjs
@@ -63,7 +63,7 @@ export default class Rescue extends Model {
   @column(type.STRING, { allowNull: true })
   static system = undefined
 
-  @validate({ len: [1, rescueTitleMaxLength], isAlphanumeric: true })
+  @validate({ len: [1, rescueTitleMaxLength] })
   @column(type.STRING, { allowNull: true })
   static title = undefined
 

--- a/src/helpers/Validators.mjs
+++ b/src/helpers/Validators.mjs
@@ -14,7 +14,7 @@ const requiredQuoteFields = [
 ]
 
 export const IRCVirtualHost = /^[a-z][a-z0-9.]{3,64}$/u
-export const IRCNickname = /^[A-Za-z_\\`\[\]{}]([A-Za-z0-9_\\`\[\]{}\-]{1,29})?$/u
+export const IRCNickname = /^[A-Za-z_\\`\[\]{}]([A-Za-z0-9_\\`\[\]{}\-|]{1,29})?$/u
 export const languageCode = /^[a-z]{2}-[A-Z]{2}$/u
 export const stripeUserId = /cus_[A-Za-z0-9]{14}$/u
 

--- a/src/helpers/Validators.mjs
+++ b/src/helpers/Validators.mjs
@@ -14,7 +14,7 @@ const requiredQuoteFields = [
 ]
 
 export const IRCVirtualHost = /^[a-z][a-z0-9.]{3,64}$/u
-export const IRCNickname = /^[A-Za-z_\\`\[\]{}]([A-Za-z0-9_\\`\[\]{}]{1,29})?$/u
+export const IRCNickname = /^[A-Za-z_\\`\[\]{}]([A-Za-z0-9_\\`\[\]{}\-]{1,29})?$/u
 export const languageCode = /^[a-z]{2}-[A-Z]{2}$/u
 export const stripeUserId = /cus_[A-Za-z0-9]{14}$/u
 

--- a/src/routes/Errors.mjs
+++ b/src/routes/Errors.mjs
@@ -1,0 +1,39 @@
+import * as errors from '../classes/APIError'
+import { websocket } from '../classes/WebSocket'
+import API, { GET } from './API'
+
+/**
+ * Endpoints for requesting any API error to be thrown, for usage by clients for testing.
+ */
+export default class Errors extends API {
+  /**
+   * Endpoint for requesting a specific API error be thrown by name
+   * @endpoint
+   */
+  @GET('/errors/:code')
+  @websocket('errors', 'read')
+  read (ctx) {
+    const { code } = ctx.params
+
+    const RequestedError = Object.values(errors).find((APIError) => {
+      return (new APIError({})).status === code
+    })
+
+    if (!RequestedError) {
+      throw new errors.NotFoundAPIError({ parameter: 'code' })
+    }
+
+    throw new RequestedError({
+      parameter: 'test',
+      pointer: '/data/attributes/test',
+    })
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get type () {
+    return 'errors'
+  }
+}
+

--- a/src/routes/Rescues.mjs
+++ b/src/routes/Rescues.mjs
@@ -156,7 +156,7 @@ export default class Rescues extends APIResource {
     await Rescue.update({
       deletedAt: new Date(),
       lastModifiedById: ctx.state.user.id,
-    }, { id: rescue.id })
+    }, { where: { id: rescue.result.id } })
 
     Event.broadcast('fuelrats.rescuedelete', ctx.state.user, {
       id: ctx.params.id,

--- a/src/routes/index.mjs
+++ b/src/routes/index.mjs
@@ -1,6 +1,7 @@
 export Anniversaries from './Anniversaries'
 export Clients from './Clients'
 export Decals from './Decals'
+export Errors from './Errors'
 export Epics from './Epics'
 export Frontier from './Frontier'
 export Groups from './Groups'


### PR DESCRIPTION
* Fix an issue where some IRC nicknames were incorrectly treated as invalid
* Add an endpoint for requesting example API errors
* Fix an issue that prevented rescue titles from being more than one word
* Fix an issue that prevented rescues from being updated