### PR TITLE
API-324/Improve the loading of JSON resources

### DIFF
--- a/localisations.json
+++ b/localisations.json
@@ -1,38 +1,6 @@
 {
   "en": {
     "translation": {
-      "rescues": "rescue",
-      "rescues_plural": "rescues",
-      "clients": "OAuth Client",
-      "clients_plural": "OAuth Clients",
-      "rats": "rat",
-      "rats_plural": "rats",
-      "users": "user profile",
-      "users_plural": "user profiles",
-      "group": "user permissions",
-      "groups_plural": "user permissions",
-      "decals": "decal",
-      "decals_plural": "decals",
-      "ships": "ship",
-      "ships_plural": "ships",
-
-      "permissionReadAll": "View {{group}}",
-      "permissionReadAll_plural": "View all {{group}}",
-      "permissionReadOwn": "View your {{group}}",
-      "permissionReadOwn_plural": "View all your {{group}}",
-      "permissionWriteAll": "Modify {{group}}",
-      "permissionWriteAll_plural": "Modify all {{group}}",
-      "permissionWriteOwn": "Modify your {{group}}",
-      "permissionWriteOwn_plural": "Modify all your {{group}}",
-      "permissionDeleteAll": "Delete {{group}}",
-      "permissionDeleteAll_plural": "Delete all {{group}}",
-      "permissionDeleteOwn": "Delete your {{group}}",
-      "permissionDeleteOwn_plural": "Delete all your {{group}}",
-      "permissionGroupAll": "Modify user permissions",
-      "permissionGroupAll_plural": "Modify all user permissions",
-      "permissionGroupOwn": "Modify your permissions",
-      "permissionGroupOwn_plural": "Modify your permissions",
-
       "bad_request": {
         "title": "Bad Request",
         "detail": "The server cannot or will not process the request due to something that is perceived to be a client error"

--- a/src/Documents/Document.mjs
+++ b/src/Documents/Document.mjs
@@ -1,13 +1,11 @@
-import fs from 'fs'
 import { URL } from 'url'
 import config from '../config'
+import packageInfo from '../files/package'
 import enumerable from '../helpers/Enum'
 import Query from '../query'
 import View from '../view'
 
 const jsonApiVersion = '1.0'
-
-const packageInfo = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 
 /**
  * @classdesc A JSONAPI Document renderer

--- a/src/classes/APIError.mjs
+++ b/src/classes/APIError.mjs
@@ -1,17 +1,9 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
-import fs from 'fs'
-import i18next from 'i18next'
 import UUID from 'pure-uuid'
+import i18next from './Localisation'
 import StatusCode from './StatusCode'
 
-const localisationResources = JSON.parse(fs.readFileSync('localisations.json', 'utf8'))
-
-// noinspection JSIgnoredPromiseFromCall
-i18next.init({
-  lng: 'en',
-  resources: localisationResources,
-})
 
 /**
  * @classdesc API error base class

--- a/src/classes/EventStream.js
+++ b/src/classes/EventStream.js
@@ -1,4 +1,4 @@
-import { build } from '../routes/Version'
+import buildFile from '../files/build'
 import { Context } from './Context'
 import StatusCode from './StatusCode'
 
@@ -38,7 +38,7 @@ export default class EventStream {
 
     const {
       hash, branch, tags, date, version,
-    } = build
+    } = buildFile
 
     eventStream.send({
       event: 'version',

--- a/src/classes/Localisation.mjs
+++ b/src/classes/Localisation.mjs
@@ -1,0 +1,13 @@
+import fs from 'fs'
+import i18next from 'i18next'
+
+const localisationFile = JSON.parse(fs.readFileSync('localisations.json', 'utf8'))
+
+// noinspection JSIgnoredPromiseFromCall
+i18next.init({
+  lng: 'en',
+  resources: localisationFile,
+})
+
+export default i18next
+

--- a/src/classes/Permission.mjs
+++ b/src/classes/Permission.mjs
@@ -1,16 +1,6 @@
-import fs from 'fs'
-import i18next from 'i18next'
+import permissionList from '../files/permissions'
 import { UnprocessableEntityAPIError } from './APIError'
 import { Context } from './Context'
-
-const localisationResources = JSON.parse(fs.readFileSync('localisations.json', 'utf8'))
-const permissionList = JSON.parse(fs.readFileSync('permissions.json', 'utf8'))
-
-// noinspection JSIgnoredPromiseFromCall
-i18next.init({
-  lng: 'en',
-  resources: localisationResources,
-})
 
 
 /**

--- a/src/files/build.mjs
+++ b/src/files/build.mjs
@@ -1,0 +1,5 @@
+import fs from 'fs'
+
+const buildFile = JSON.parse(fs.readFileSync('build.json', 'utf8'))
+
+export default buildFile

--- a/src/files/package.mjs
+++ b/src/files/package.mjs
@@ -1,0 +1,6 @@
+import fs from 'fs'
+
+const packageFile = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+
+export default packageFile
+

--- a/src/files/permissions.mjs
+++ b/src/files/permissions.mjs
@@ -1,0 +1,5 @@
+import fs from 'fs'
+
+const permissionFile = JSON.parse(fs.readFileSync('permissions.json', 'utf8'))
+
+export default permissionFile

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -26,12 +26,11 @@ import TrafficControl from './classes/TrafficControl'
 import WebSocket from './classes/WebSocket'
 import config from './config'
 import { db } from './db'
+import packageInfo from './files/package'
 import logger from './logging'
 import Query from './query'
 import * as routes from './routes'
 import oauth2 from './routes/OAuth2'
-
-const packageInfo = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 
 
 const app = new Koa()

--- a/src/routes/OAuth2.mjs
+++ b/src/routes/OAuth2.mjs
@@ -1,6 +1,4 @@
 import crypto from 'crypto'
-import fs from 'fs'
-import i18next from 'i18next'
 import oauth2orize from 'oauth2orize-koa-fr'
 import {
   ForbiddenAPIError,
@@ -28,13 +26,6 @@ import API, {
 import Sessions from './Sessions'
 
 const mail = new Mail()
-const localisationResources = JSON.parse(fs.readFileSync('localisations.json', 'utf8'))
-
-// noinspection JSIgnoredPromiseFromCall
-i18next.init({
-  lng: 'en',
-  resources: localisationResources,
-})
 
 const server = oauth2orize.createServer()
 
@@ -208,7 +199,6 @@ class OAuth2 extends API {
       transactionId: ctx.state.oauth2.transactionID,
       user: ctx.user,
       client,
-      scopes: Permission.humanReadable({ scopes: ctx.state.oauth2.req.scope, connection: ctx }),
       scope: ctx.state.oauth2.req.scope.join(' '),
     }
   }

--- a/src/routes/Version.mjs
+++ b/src/routes/Version.mjs
@@ -1,14 +1,12 @@
-import fs from 'fs'
 import { DocumentViewType } from '../Documents'
 import ObjectDocument from '../Documents/ObjectDocument'
 import { websocket } from '../classes/WebSocket'
+import buildFile from '../files/build'
 import Query from '../query'
 import { VersionView } from '../view'
 import API, {
   GET,
 } from './API'
-
-export const build = JSON.parse(fs.readFileSync('build.json', 'utf8'))
 
 /**
  * API endpoint to get API version information
@@ -30,7 +28,7 @@ export default class Version extends API {
   read (ctx) {
     const {
       hash, branch, tags, date, version,
-    } = build
+    } = buildFile
 
     const result = {
       version,


### PR DESCRIPTION
Move to loading JSON resources in single modules that can be imported by other modules.
Also removes the "human readable" oauth scope descriptions as this will now be generated by the front-end.