### PR TITLE
API-331/Make password changes use transactions.

### DIFF
--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -234,9 +234,13 @@ export default class Users extends APIResource {
       throw new UnauthorizedAPIError({ pointer: '/data/attributes/password' })
     }
 
-    user.password = newPassword
-    await user.save()
-    await Anope.setPassword(user.email, user.password)
+    await db.transaction(async (transaction) => {
+      user.password = newPassword
+      await user.save({ transaction })
+      await Anope.setPassword(user.email, user.password)
+
+      return user
+    })
 
     const result = await Anope.mapNickname(user)
 


### PR DESCRIPTION
Move to transactions so that user password change is rolled back if Anope change does not complete successfully, the current code could result in a state where the API user and the IRC user had different passwords