### PR TITLE
Fix group write permission check

### DIFF
--- a/src/routes/APIResource.mjs
+++ b/src/routes/APIResource.mjs
@@ -495,7 +495,7 @@ export default class APIResource extends API {
           return isGroup
 
         case WritePermission.group:
-          return isGroup ?? isSelf
+          return isGroup || isSelf
 
         case WritePermission.self:
           return isSelf


### PR DESCRIPTION
This PR fixes a logic error in checking write permissions for fields with the `group` permission.