### PR TITLE
Buncha Avatar related stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
-
+.env
 
 ### OSX ###
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xlexious <alex@sorlie.co.uk>"
   ],
   "scripts": {
-    "dev": "node --harmony dist/index.js",
+    "dev": "node --inspect --harmony dist/index.mjs",
     "build": "rollup --config",
     "test": "NODE_ENV=testing node --harmony test",
     "jsdoc": "jsdoc -d static/docs/js -rgoo api",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,18 +25,29 @@ Promise.all([
   })
 })
 
-const config = {
-  input: 'src/index.mjs',
-  output: {
-    dir: 'dist',
-    format: 'esm',
-    entryFileNames: '[name].mjs',
-    sourcemap: true,
-  },
-  external: ['nanoid/async'],
-  preserveModules: true,
-  plugins: [autoExternal(), json(), resolve(), babel({ externalHelpers: true })],
+
+
+const defineEntry = (input, outputDir) => {
+  return {
+    input,
+    output: {
+      dir: outputDir,
+      format: 'esm',
+      entryFileNames: '[name].mjs',
+      sourcemap: true,
+    },
+    external: ['nanoid/async'],
+    preserveModules: true,
+    plugins: [autoExternal(), json(), resolve(), babel({ externalHelpers: true })],
+  }
 }
+
+const config = [
+  defineEntry('src/index.mjs', 'dist'),
+  defineEntry('src/workers/certificate.mjs', 'dist/workers'),
+  defineEntry('src/workers/image.mjs', 'dist/workers'),
+]
+
 
 export default config
 

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -9,6 +9,7 @@ import {
   UnsupportedMediaAPIError,
   BadRequestAPIError,
   InternalServerError,
+  ImATeapotAPIError,
 } from '../classes/APIError'
 import Announcer from '../classes/Announcer'
 import Anope from '../classes/Anope'
@@ -44,7 +45,7 @@ import Verifications from './Verifications'
 const mail = new Mail()
 
 const avatarCacheTime = 604800000 // 1 Week
-const validAvatarFormats = ['webp', 'jpeg']
+const validAvatarFormats = ['webp', 'png', 'jpeg']
 const defaultAvatarFormat = 'webp'
 const avatarMinSize = 32
 const avatarMaxSize = 256
@@ -362,8 +363,9 @@ export default class Users extends APIResource {
     this.requireWritePermission({ connection: ctx, entity: user })
 
     if (!ctx.request.files?.image) {
-      throw new BadRequestAPIError({ pointer: 'image' })
+      throw new ImATeapotAPIError()
     }
+
     const imageData = await fsp.readFile(ctx.request.files.image.path)
 
     const formattedImageData = await Users.convertImageData(imageData, {

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -368,10 +368,7 @@ export default class Users extends APIResource {
 
     const imageData = await fsp.readFile(ctx.request.files.image.path)
 
-    const formattedImageData = await Users.convertImageData(imageData, {
-      format: defaultAvatarFormat,
-      size: avatarMaxSize,
-    })
+    const formattedImageData = await Users.convertImageData(imageData)
 
     await Avatar.destroy({
       where: {

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -12,6 +12,7 @@ import {
 import Announcer from '../classes/Announcer'
 import Anope from '../classes/Anope'
 import { Context } from '../classes/Context'
+import Event from '../classes/Event'
 import Mail from '../classes/Mail'
 import Permission from '../classes/Permission'
 import StatusCode from '../classes/StatusCode'
@@ -38,7 +39,6 @@ import {
 import APIResource from './APIResource'
 import Decals from './Decals'
 import Verifications from './Verifications'
-import Event from '../classes/Event.mjs'
 
 const mail = new Mail()
 
@@ -186,7 +186,9 @@ export default class Users extends APIResource {
 
       user.email = email
       await user.save({ transaction })
-      const verifiedGroup = user.groups.find((group) => { return group.name === 'verified' })
+      const verifiedGroup = user.groups.find((group) => {
+        return group.name === 'verified'
+      })
       if (verifiedGroup) {
         await user.removeGroup(verifiedGroup, { transaction })
       }

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -888,8 +888,8 @@ export default class Users extends APIResource {
    * Contact the image processing web worker to process an image into the correct format and size
    * @param {Buffer} originalImageData the original image data
    * @param {object?} options Output options for the transformed image data
-   * @param {number} options.size Output size of the image
-   * @param {string} options.format Output format of the image
+   * @param {number?} options.size Output size of the image
+   * @param {string?} options.format Output format of the image
    * @returns {Promise<Buffer>} processed image data
    */
   static async convertImageData (originalImageData, options = {}) {

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -46,8 +46,8 @@ const mail = new Mail()
  * Class for the /users endpoint
  */
 export default class Users extends APIResource {
-  static imageResizePool = workerpool.pool('./dist/workers/image.js')
-  static sslGenerationPool = workerpool.pool('./dist/workers/certificate.js')
+  static imageFormatPool = workerpool.pool('./dist/workers/image.mjs')
+  static sslGenerationPool = workerpool.pool('./dist/workers/certificate.mjs')
 
   /**
    * @inheritdoc

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -1,4 +1,5 @@
 import bcrypt from 'bcrypt'
+import { promises as fsp } from 'fs'
 import workerpool from 'workerpool'
 import DatabaseDocument from '../Documents/DatabaseDocument'
 import { DocumentViewType } from '../Documents/Document'
@@ -41,6 +42,12 @@ import Decals from './Decals'
 import Verifications from './Verifications'
 
 const mail = new Mail()
+
+const avatarCacheTime = 604800000 // 1 Week
+const validAvatarFormats = ['webp', 'jpeg']
+const defaultAvatarFormat = 'webp'
+const avatarMinSize = 32
+const avatarMaxSize = 256
 
 /**
  * Class for the /users endpoint
@@ -128,8 +135,27 @@ export default class Users extends APIResource {
       throw new NotFoundAPIError({ parameter: 'id' })
     }
 
-    ctx.type = 'image/jpeg'
-    ctx.body = avatar.image
+    const { format = defaultAvatarFormat } = ctx.query
+    const size = parseInt(ctx.query.size ?? avatarMaxSize, 10)
+
+    if (format !== defaultAvatarFormat || size !== avatarMaxSize) {
+      if (!validAvatarFormats.includes(format)) {
+        throw new BadRequestAPIError({ parameter: 'format' })
+      }
+
+
+      if (Number.isNaN(size) || size < avatarMinSize || size > avatarMaxSize) {
+        throw new BadRequestAPIError({ parameter: 'size' })
+      }
+
+      ctx.body = await Users.convertImageData(avatar.image, { format, size })
+    } else {
+      ctx.body = avatar.image
+    }
+
+    ctx.set('Expires', new Date(Date.now() + avatarCacheTime).toUTCString())
+    ctx.type = `image/${format}`
+
     next()
   }
 
@@ -335,9 +361,15 @@ export default class Users extends APIResource {
 
     this.requireWritePermission({ connection: ctx, entity: user })
 
-    const imageData = ctx.req._readableState.buffer.head.data
+    if (!ctx.request.files?.image) {
+      throw new BadRequestAPIError({ pointer: 'image' })
+    }
+    const imageData = await fsp.readFile(ctx.request.files.image.path)
 
-    const formattedImageData = await Users.convertImageData(imageData)
+    const formattedImageData = await Users.convertImageData(imageData, {
+      format: defaultAvatarFormat,
+      size: avatarMaxSize,
+    })
 
     await Avatar.destroy({
       where: {
@@ -856,13 +888,20 @@ export default class Users extends APIResource {
   /**
    * Contact the image processing web worker to process an image into the correct format and size
    * @param {Buffer} originalImageData the original image data
+   * @param {object?} options Output options for the transformed image data
+   * @param {number} options.size Output size of the image
+   * @param {string} options.format Output format of the image
    * @returns {Promise<Buffer>} processed image data
    */
-  static async convertImageData (originalImageData) {
+  static async convertImageData (originalImageData, options = {}) {
     try {
-      return Buffer.from(await Users.imageResizePool.exec('avatarImageResize', [originalImageData]))
+      return Buffer.from(await Users.imageFormatPool.exec('avatarImageFormat', [originalImageData, {
+        size: options.size ?? avatarMaxSize,
+        format: options.format ?? defaultAvatarFormat,
+      }]))
     } catch (error) {
       if (error.message.includes('unsupported image format')) {
+        // Thrown when input format is unsupported
         throw new UnsupportedMediaAPIError({})
       } else {
         throw error

--- a/src/workers/image.mjs
+++ b/src/workers/image.mjs
@@ -1,24 +1,35 @@
 import sharp from 'sharp'
 import workerpool from 'workerpool'
 
-const profileImageMax = 256
+const formatOptions = {
+  webp: {
+    quality: 80,
+  },
+  jpeg: {
+    quality: 80,
+    chromaSubsampling: '4:4:4',
+  },
+}
 
 /**
  * Web worker that formats converts an image to an appropriate format and resolution for avatars
  * @param {Uint8Array} imageDataPackage Data buffer package containing image data
- * @returns {Promise<any>} A transformed data buffer or an error
+ * @param {object} options Output options for the transformed image data
+ * @param {number} options.size Output size of the image
+ * @param {string} options.format Output format of the image
+ * @returns {Promise<Buffer>} A transformed data buffer or an error
+ * @throws {Error} Unsupported format or options
  */
-function avatarImageResize (imageDataPackage) {
+function avatarImageFormat (imageDataPackage, options) {
+  const { format, size } = options
+
   return sharp(Buffer.from(imageDataPackage))
-    .resize(profileImageMax, profileImageMax)
-    .jpeg({
-      quality: 80,
-      chromaSubsampling: '4:4:4',
-    })
+    .resize(size, size)
+    .toFormat(format, formatOptions[format])
     .toBuffer()
 }
 
 workerpool.worker({
-  avatarImageResize,
+  avatarImageFormat,
 })
 


### PR DESCRIPTION
We are currently working on improved avatar handling on the front end, and I wanted to add these features for parity with the default avatar service. Along the way I discovered a few bugs and problem spots which I smoothed out as well

#### Changelog
* Fixed issue with Rollup not processing worker modules since they aren't conventionally imported.
* Added `format` and `size` query parameters to `GET /users/:id/image`
    * `format`: one of `['webp', 'png', 'jpeg']`. Default: `'webp'`
    * `size`: valid `number` that is `>=32` and `<=256`. Default: `256`.
    * If parameters provided are other than default, the image is resized/reformatted to fit. Otherwise, the stored image is provided.
    * If paramaters are invalid, `BadRequestAPIError` is thrown.
* Changed upload method of `POST /users/:id/image`.
    * This endpoint now expects `multipart/form-data` which contains a file upload named `image`.
    * If `image` is missing, the API will hilariously throw an `ImATeapotAPIError`
* Image worker now **requires** an `options` object
    * Object requires output `format` and `size`.
    * `format`-specific option defaults are set for `webp` and `jpeg`.
* Avatars are now stored as `256x` `.webp` images.
* Added `.env` file to `.gitignore`.
    * This is for local envvar storage. I have a tool which loads this file on runtime.
* Fixed a couple stylistic lint issues in the files modified.