### PR TITLE
Fixing avatar issues & improving configs!

### DIFF
--- a/src/config.mjs
+++ b/src/config.mjs
@@ -4,45 +4,46 @@ import {
   optional,
   recommended,
   ensureValidConfig,
-  isBoolean,
-  isArray,
+  isBaseUrl,
   isIrcChannel,
-  isNumber,
   isUUID,
+  toArray,
+  toStrictBoolean,
+  toNumber,
 } from './helpers/ConfigValidators'
 
 const config = {
   server: {
     hostname: required('FRAPI_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_PORT', [isNumber], 8080),
-    externalUrl: required('FRAPI_URL', [], 'http://localhost:8080'),
+    port: required('FRAPI_PORT', [toNumber], 8080),
+    externalUrl: required('FRAPI_URL', [isBaseUrl], 'http://localhost:8080'),
     cookieSecret: required('FRAPI_COOKIE', [], undefined),
-    proxyEnabled: required('FRAPI_PROXY_ENABLED', [isBoolean], false),
-    whitelist: optional('FRAPI_WHITELIST', [isArray], []),
+    proxyEnabled: required('FRAPI_PROXY_ENABLED', [toStrictBoolean], false),
+    whitelist: optional('FRAPI_WHITELIST', [toArray], []),
   },
   documentationUrl: required('FRAPI_DOCUMENTATION', [], 'https://github.com/FuelRats/FuelRats-API-Docs/blob/master/beta.md'),
   frontend: {
     clientId: recommended('FRAPI_FRONTEND_CLIENTID', [isUUID], undefined),
-    url: required('FRAPI_FRONTEND_URL', [], 'https://fuelrats.com'),
+    url: required('FRAPI_FRONTEND_URL', [isBaseUrl], 'https://fuelrats.com'),
   },
   postgres: {
     database: required('FRAPI_POSTGRES_DATABASE', [], 'fuelrats'),
     hostname: required('FRAPI_POSTGRES_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_POSTGRES_PORT', [isNumber], 5432),
+    port: required('FRAPI_POSTGRES_PORT', [toNumber], 5432),
     username: required('FRAPI_POSTGRES_USERNAME', [], 'fuelrats'),
     password: optional('FRAPI_POSTGRES_PASSWORD', [], undefined),
   },
   anope: {
     database: required('FRAPI_ANOPE_DATABASE', [], 'anope'),
     hostname: required('FRAPI_ANOPE_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_ANOPE_PORT', [isNumber], 3306),
+    port: required('FRAPI_ANOPE_PORT', [toNumber], 3306),
     username: required('FRAPI_ANOPE_USERNAME', [], 'anope'),
     password: optional('FRAPI_ANOPE_PASSWORD', [], undefined),
   },
   irc: {
     server: recommended('FRAPI_IRC_SERVER', [], undefined),
     serverName: recommended('FRAPI_IRC_SERVERNAME', [], undefined),
-    port: recommended('FRAPI_IRC_PORT', [isNumber], 6900),
+    port: recommended('FRAPI_IRC_PORT', [toNumber], 6900),
     password: recommended('FRAPI_IRC_PASSWORD', [], undefined),
   },
   geoip: {
@@ -66,7 +67,7 @@ const config = {
   },
   graylog: {
     host: recommended('FRAPI_GRAYLOG_HOST', [], undefined),
-    port: recommended('FRAPI_GRAYLOG_PORT', [isNumber], 12201),
+    port: recommended('FRAPI_GRAYLOG_PORT', [toNumber], 12201),
     facility: recommended('FRAPI_GRAYLOG_FACILITY', [], 'fuelratsapi'),
   },
   slack: {
@@ -75,7 +76,7 @@ const config = {
   },
   smtp: {
     hostname: recommended('FRAPI_SMTP_HOSTNAME', [], 'smtp-relay.gmail.com'),
-    port: recommended('FRAPI_SMTP_PORT', [isNumber], 587),
+    port: recommended('FRAPI_SMTP_PORT', [toNumber], 587),
     sender: recommended('FRAPI_SMTP_SENDER', [], 'blackhole@fuelrats.com'),
   },
   jira: {

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -1,39 +1,48 @@
-/* eslint-disable no-magic-numbers,no-console */
-let configErrors = 0
-let configWarnings = 0
+/* eslint-disable no-magic-numbers */
+import {
+  required,
+  optional,
+  recommended,
+  ensureValidConfig,
+  isBoolean,
+  isArray,
+  isIrcChannel,
+  isNumber,
+  isUUID,
+} from './helpers/ConfigValidators'
 
 const config = {
   server: {
     hostname: required('FRAPI_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_PORT', [], 8080),
+    port: required('FRAPI_PORT', [isNumber], 8080),
     externalUrl: required('FRAPI_URL', [], 'http://localhost:8080'),
-    cookieSecret: required('FRAPI_COOKIE', []),
-    proxyEnabled: required('FRAPI_PROXY_ENABLED', [], false),
-    whitelist: optional('FRAPI_WHITELIST', [], []),
+    cookieSecret: required('FRAPI_COOKIE', [], undefined),
+    proxyEnabled: required('FRAPI_PROXY_ENABLED', [isBoolean], false),
+    whitelist: optional('FRAPI_WHITELIST', [isArray], []),
   },
   documentationUrl: required('FRAPI_DOCUMENTATION', [], 'https://github.com/FuelRats/FuelRats-API-Docs/blob/master/beta.md'),
   frontend: {
-    clientId: recommended('FRAPI_FRONTEND_CLIENTID', []),
+    clientId: recommended('FRAPI_FRONTEND_CLIENTID', [isUUID], undefined),
     url: required('FRAPI_FRONTEND_URL', [], 'https://fuelrats.com'),
   },
   postgres: {
     database: required('FRAPI_POSTGRES_DATABASE', [], 'fuelrats'),
     hostname: required('FRAPI_POSTGRES_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_POSTGRES_PORT', [], 5432),
+    port: required('FRAPI_POSTGRES_PORT', [isNumber], 5432),
     username: required('FRAPI_POSTGRES_USERNAME', [], 'fuelrats'),
     password: optional('FRAPI_POSTGRES_PASSWORD', [], undefined),
   },
   anope: {
     database: required('FRAPI_ANOPE_DATABASE', [], 'anope'),
     hostname: required('FRAPI_ANOPE_HOSTNAME', [], 'localhost'),
-    port: required('FRAPI_ANOPE_PORT', [], 3306),
+    port: required('FRAPI_ANOPE_PORT', [isNumber], 3306),
     username: required('FRAPI_ANOPE_USERNAME', [], 'anope'),
     password: optional('FRAPI_ANOPE_PASSWORD', [], undefined),
   },
   irc: {
     server: recommended('FRAPI_IRC_SERVER', [], undefined),
     serverName: recommended('FRAPI_IRC_SERVERNAME', [], undefined),
-    port: recommended('FRAPI_IRC_PORT', [], 6900),
+    port: recommended('FRAPI_IRC_PORT', [isNumber], 6900),
     password: recommended('FRAPI_IRC_PASSWORD', [], undefined),
   },
   geoip: {
@@ -43,11 +52,11 @@ const config = {
     url: recommended('FRAPI_ANNOUNCER,URL', [], 'https://announcer-dev.fuelrats.com/api'),
     secret: recommended('FRAPI_ANNOUNCER_SECRET', [], undefined),
     destinations: {
-      rescue: recommended('FRAPI_ANNOUNCER_DESTINATION_RESCUE', [], '#ratchat'),
-      moderation: recommended('FRAPI_ANNOUNCER_DESTINATION_MODERATION', [], '#rat-ops'),
-      network: recommended('FRAPI_ANNOUNCER_DESTINATION_NETWORK', [], '#opers'),
-      technical: recommended('FRAPI_ANNOUNCER_DESTINATION_TECHNICAL', [], '#rattech'),
-      drill: recommended('FRAPI_ANNOUNCER_DESTINATION_DRILL', [], '#doersofstuff'),
+      rescue: recommended('FRAPI_ANNOUNCER_DESTINATION_RESCUE', [isIrcChannel], '#ratchat'),
+      moderation: recommended('FRAPI_ANNOUNCER_DESTINATION_MODERATION', [isIrcChannel], '#rat-ops'),
+      network: recommended('FRAPI_ANNOUNCER_DESTINATION_NETWORK', [isIrcChannel], '#opers'),
+      technical: recommended('FRAPI_ANNOUNCER_DESTINATION_TECHNICAL', [isIrcChannel], '#rattech'),
+      drill: recommended('FRAPI_ANNOUNCER_DESTINATION_DRILL', [isIrcChannel], '#doersofstuff'),
     },
   },
   frontier: {
@@ -57,7 +66,7 @@ const config = {
   },
   graylog: {
     host: recommended('FRAPI_GRAYLOG_HOST', [], undefined),
-    port: recommended('FRAPI_GRAYLOG_PORT', [], 12201),
+    port: recommended('FRAPI_GRAYLOG_PORT', [isNumber], 12201),
     facility: recommended('FRAPI_GRAYLOG_FACILITY', [], 'fuelratsapi'),
   },
   slack: {
@@ -66,7 +75,7 @@ const config = {
   },
   smtp: {
     hostname: recommended('FRAPI_SMTP_HOSTNAME', [], 'smtp-relay.gmail.com'),
-    port: recommended('FRAPI_SMTP_PORT', [], 587),
+    port: recommended('FRAPI_SMTP_PORT', [isNumber], 587),
     sender: recommended('FRAPI_SMTP_SENDER', [], 'blackhole@fuelrats.com'),
   },
   jira: {
@@ -81,85 +90,10 @@ const config = {
   },
 }
 
-console.log(`${configErrors} config errors.`)
-console.log(`${configWarnings} config warnings.`)
-if (configErrors > 0) {
-  console.log('FATAL CONFIGURATION PROBLEMS DETECTED, EXITING')
-  process.abort()
-}
+ensureValidConfig()
 
-/**
- * Require a config environment variable. This setting will cause a fatal error if invalid
- * @param {string} property The environment variable name
- * @param {[Function]} validations array of validation functions to run
- * @param {*} defaultValue default value to be provided for this, if any
- * @returns {*|undefined}
- */
-function required (property, validations = [], defaultValue = undefined) {
-  const value = process.env[property] ?? defaultValue
-  if (typeof value === 'undefined') {
-    console.error(`FATAL ERROR: Required config parameter ${property} is not provided`)
-    configErrors += 1
-    return undefined
-  }
 
-  validations.forEach((validation) => {
-    const validationMessage = validation.call(value, value)
-    if (validationMessage !== true) {
-      console.error(`FATAL ERROR: Required config parameter ${property} did not pass validation. ${validationMessage}`)
-      configErrors += 1
-    }
-  })
 
-  return value
-}
 
-/**
- * Set a recommended config environment variable. This setting will generate a warning if invalid
- * @param {string} property The environment variable name
- * @param {[Function]} validations array of validation functions to run
- * @param {*} defaultValue default value to be provided for this, if any
- * @returns {*|undefined}
- */
-function recommended (property, validations = [], defaultValue = undefined) {
-  const value = process.env[property] ?? defaultValue
-  if (typeof value === 'undefined') {
-    console.error(`WARNING: Config parameter ${property} is not configured, 
-    functionality will be limited and/or unstable`)
-    configWarnings += 1
-    return undefined
-  }
-
-  validations.forEach((validation) => {
-    const validationMessage = validation.call(value, value)
-    if (validationMessage !== true) {
-      console.warn(`WARNING: Config parameter ${property} did not pass validation. ${validationMessage}`)
-      configWarnings += 1
-    }
-  })
-
-  return value
-}
-
-/**
- * Set an optional config environment variable. This setting will generate a warning only if it fails validation
- * @param {string} property The environment variable name
- * @param {[Function]} validations array of validation functions to run
- * @param {*} defaultValue default value to be provided for this, if any
- * @returns {*|undefined}
- */
-function optional (property, validations, defaultValue = undefined) {
-  const value = process.env[property] ?? defaultValue
-
-  validations.forEach((validation) => {
-    const validationMessage = validation.call(value, value)
-    if (validationMessage !== true) {
-      console.warn(`WARNING: Config parameter ${property} did not pass validation. ${validationMessage}`)
-      configWarnings += 1
-    }
-  })
-
-  return value
-}
 
 export default config

--- a/src/db/Avatar.mjs
+++ b/src/db/Avatar.mjs
@@ -12,16 +12,29 @@ export default class Avatar extends Model {
   @column(type.BLOB())
   static image = undefined
 
+  @validate({ isUUID: 4 })
+  @column(type.UUID, { allowNull: true })
+  static userId = undefined
+
   /**
    * @inheritdoc
    */
-  static getScopes () {
+  static getScopes (models) {
     return {
       defaultScope: [{
-        attributes: ['id'],
+        attributes: {
+          exclude: ['image'],
+        },
+        include: [
+          {
+            model: models.User,
+            as: 'user',
+            required: true,
+          },
+        ],
       }],
 
-      data: [{
+      imageData: [{
         attributes: ['id', 'image'],
       }],
     }
@@ -33,6 +46,6 @@ export default class Avatar extends Model {
   static associate (models) {
     super.associate(models)
 
-    models.Avatar.belongsTo(models.User, { as: 'user' })
+    models.Avatar.belongsTo(models.User, { as: 'user', foreignKey: 'userId' })
   }
 }

--- a/src/db/Avatar.mjs
+++ b/src/db/Avatar.mjs
@@ -27,9 +27,9 @@ export default class Avatar extends Model {
         },
         include: [
           {
-            model: models.User,
+            model: models.User.scope('norelations'),
             as: 'user',
-            required: true,
+            required: false,
           },
         ],
       }],

--- a/src/db/User.mjs
+++ b/src/db/User.mjs
@@ -49,18 +49,6 @@ export default class User extends Model {
   @column(type.DATE, { allowNull: true })
   static suspended = undefined
 
-  @column(type.VIRTUAL(type.BOOLEAN), {
-    include: [],
-    get () {
-      // This is a workaround hack so image is not included in 'norelation' scope.
-      // Virtual/Getter columns cannot be excluded, and the issue still exists even on the latest version of Sequelize.
-      // Assume that no avatar = unknown state, so don't include it.
-      return this.avatar ? true : undefined
-    },
-    allowNull: true,
-  })
-  static image = undefined
-
   @column(type.VIRTUAL(type.ARRAY(type.STRING)), {
     include: [],
     get () {
@@ -201,7 +189,6 @@ export default class User extends Model {
         attributes: {
           exclude: [
             'permissions',
-            'image',
           ],
         },
         include: [
@@ -254,7 +241,6 @@ export default class User extends Model {
         attributes: {
           exclude: [
             'permissions',
-            'image',
           ],
         },
       }, { override: true }],

--- a/src/db/User.mjs
+++ b/src/db/User.mjs
@@ -52,7 +52,10 @@ export default class User extends Model {
   @column(type.VIRTUAL(type.BOOLEAN), {
     include: [],
     get () {
-      return Boolean(this.avatar)
+      // This is a workaround hack so image is not included in 'norelation' scope.
+      // Virtual/Getter columns cannot be excluded, and the issue still exists even on the latest version of Sequelize.
+      // Assume that no avatar = unknown state, so don't include it.
+      return this.avatar ? true : undefined
     },
     allowNull: true,
   })

--- a/src/db/index.mjs
+++ b/src/db/index.mjs
@@ -23,8 +23,8 @@ import UserGroups from './UserGroups'
 import VerificationToken from './VerificationToken'
 
 const models = {
-  Avatar,
   User,
+  Avatar,
   Rat,
   Rescue,
   RescueRats,

--- a/src/helpers/ConfigValidators.mjs
+++ b/src/helpers/ConfigValidators.mjs
@@ -3,7 +3,6 @@ import { IRCChannel, UUID } from './Validators'
 
 
 
-
 let configErrors = 0
 let configWarnings = 0
 
@@ -16,7 +15,6 @@ class ValidatorContext {
   property = ''
   value = undefined
   defaultValue = undefined
-
 
   /**
    * @param {string} property The environment variable name
@@ -54,9 +52,9 @@ class ValidatorContext {
   }
 
   /**
-   * Displays an unrecoverable error with the given message.
+   * logs an unrecoverable error with the given message.
    *
-   * @param {...string} messages A list of messages to display. Each string representing a line in the message.
+   * @param {...string} messages A list of messages to display. Each argument representing a line in the message.
    */
   error (...messages) {
     console.error('FATAL ERROR', ...this._getMessage(messages))
@@ -64,30 +62,61 @@ class ValidatorContext {
   }
 
   /**
-   * Displays a warning with the given message.
+   * logs a warning with the given message.
    *
-   * @param {...string} messages A list of messages to display. Each string representing a line in the message.
+   * @param {...string} messages A list of messages to display. Each argument representing a line in the message.
    */
   warn (...messages) {
-    console.warn('WARNING:', ...this._getMessage(messages))
+    console.warn('WARNING', ...this._getMessage(messages))
     configWarnings += 1
   }
 
   /**
-   * Displays a warning which follows a standard message structure.
+   * logs a warning which follows a standard message structure, then reverts the value to default
    *
-   * @param {string} validType A string representing the expected valid type of value.
-   * @param {string?} nextValue The value that will be used instead of the provided value.
-   * @param {string?} expectedExplainer A sentance that explains what value was expected.
+   * @param {object} arg function arguments object
+   * @param {string} arg.type A string representing the expected value type.
+   * @param {string?} arg.expected A sentance that explains what was expected of the value.
    */
-  warnStructured (validType, nextValue, expectedExplainer) {
-    this.warn([
-      `Config parameter '${this.property}' was not provided a valid ${validType}.`,
-      expectedExplainer && `Expected: ${expectedExplainer}`,
-      nextValue && `Parameter will become: '${nextValue}'.`,
-    ])
+  warnSetDefault ({ type, expected }) {
+    this.warn(
+      `Config property '${this.property}' was not provided a valid ${type}.`,
+      expected && `Expected: ${expected}`,
+      `Parameter will become: '${this.defaultValue}'.`,
+    )
+    this.value = this.defaultValue
+  }
+
+  /**
+   * logs a warning which follows a standard message structure, then sets the next value.
+   *
+   * @param {object} arg function arguments object
+   * @param {string} arg.value The value that will be used instead of the provided value.
+   * @param {string} arg.type A string representing the expected value type.
+   * @param {string} arg.problem A mid-sentence string explaining the cause of the warning.
+   * @param {string?} arg.expected A sentance that explains what was expected of the value.
+   */
+  warnSetValue ({ value, type, problem, expected }) {
+    this.warn(
+      `Config property '${this.property}' was provided a valid ${type}, however ${problem}`,
+      expected && `Expected: ${expected}`,
+      `Parameter will be corrected to: '${value}'.`,
+    )
+    this.value = value
+  }
+
+  /**
+   * Convenience function for validators to determine if they should continue with validation.
+   *
+   * @param {string?} type Expected value type. (Default: `'string'`)
+   * @returns {boolean}
+   */
+  hasValue (type = 'string') {
+    return typeof this.value === type
   }
 }
+
+
 
 
 
@@ -112,16 +141,7 @@ export function optional (property, validations = [], defaultValue = undefined) 
  * @returns {*|undefined}
  */
 export function recommended (property, validations = [], defaultValue = undefined) {
-  const isRecommend = (ctx) => {
-    if (typeof ctx.value === 'undefined') {
-      ctx.warn(
-        `Recommended config parameter '${ctx.property}' is not configured.`,
-        'Functionality will be limited and/or unstable.',
-      )
-    }
-  }
-
-  return optional(property, [...validations, isRecommend], defaultValue)
+  return optional(property, [...validations, isRecommended], defaultValue)
 }
 
 /**
@@ -133,33 +153,55 @@ export function recommended (property, validations = [], defaultValue = undefine
  * @returns {*|undefined}
  */
 export function required (property, validations = [], defaultValue = undefined) {
-  const isRequired = (ctx) => {
-    if (typeof ctx.value === 'undefined') {
-      ctx.error(
-        `Required config parameter '${ctx.property}' is not configured.`,
-        'Parameter must be configured to continue!',
-      )
-    }
-  }
-
   return optional(property, [...validations, isRequired], defaultValue)
 }
 
 
+
+
+
 /**
- * Config validator that ensures the value is a valid IRC channel name as defined by RFC1459.
+ * Config validator that warns when a value is `undefined`.
+ *
+ * @see {@link recommended} Use the recommened function to define your property instead.
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isRecommended (ctx) {
+  if (typeof ctx.value === 'undefined') {
+    ctx.warn(
+      `Recommended config property '${ctx.property}' is not configured.`,
+      'Functionality will be limited and/or unstable.',
+    )
+  }
+}
+
+/**
+ * Config validator that errors when a value is `undefined`.
+ *
+ * @see {@link required} Use the required function to define your property instead.
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isRequired (ctx) {
+  if (typeof ctx.value === 'undefined') {
+    ctx.error(
+      `Required config property '${ctx.property}' is not configured.`,
+      'Parameter must be configured to continue!',
+    )
+  }
+}
+
+/**
+ * Config validator that ensures the value is a valid RFC1459 IRC channel name.
  *
  * @param {ValidatorContext} ctx Config Validator context instance
  */
 export function isIrcChannel (ctx) {
-  const { value, defaultValue } = ctx
-  if (typeof value === 'string' && !IRCChannel.test(value)) {
-    ctx.value = defaultValue
-    ctx.warnStructured(
-      'IRC Channel name',
-      defaultValue,
-      "A string that begins with '#' or '&', and contains no whitespaces or commas.",
-    )
+  const { value } = ctx
+  if (ctx.hasValue() && !IRCChannel.test(value)) {
+    ctx.warnSetDefault({
+      type: 'IRC Channel name',
+      expected: "A string that begins with '#' or '&', and contains no whitespaces or commas.",
+    })
   }
 }
 
@@ -169,16 +211,56 @@ export function isIrcChannel (ctx) {
  * @param {ValidatorContext} ctx Config Validator context instance
  */
 export function isUUID (ctx) {
-  const { value, defaultValue } = ctx
-  if (typeof value === 'string' && !UUID.test(value)) {
-    ctx.value = defaultValue
-    ctx.warnStructured(
-      'UUID',
-      defaultValue,
-      "A string in the format of 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.",
-    )
+  const { value } = ctx
+  if (ctx.hasValue() && !UUID.test(value)) {
+    ctx.warnSetDefault({
+      type: 'UUID',
+      expected: "A string in the format of 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.",
+    })
   }
 }
+
+/**
+ * Config Validator that ensures a number of factors for URL values
+ *
+ * 1. It is a valid URL (verified by URL API)
+ * 2. The URL is secure (and will error in production)
+ * 3. The URL does not end with a trailing slash, as the API will append them.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isBaseUrl (ctx) {
+  const type = 'URL'
+  const { property, value } = ctx
+  if (ctx.hasValue()) {
+    try {
+      const baseUrl = new URL(value)
+
+      if (baseUrl.protocol === 'http:') {
+        const errorMsg = `Config property '${property}' is a non-secure URL!`
+
+        if (process.env.NODE_ENV === 'production') {
+          ctx.error(errorMsg, 'A base URL MUST be secure in production mode!')
+        } else {
+          ctx.warn(errorMsg, 'This will produce an error in production mode.')
+        }
+      }
+
+      if (value.endsWith('/')) {
+        ctx.warnSetValue({
+          type,
+          value: value.replace(/\/+$/u, ''),
+          problem: 'it contains a trailing slash.',
+        })
+      }
+    } catch {
+      ctx.warnSetDefault({ type, expected: 'A string which represents a valid URL.' })
+    }
+  }
+}
+
+
+
 
 
 /**
@@ -186,9 +268,9 @@ export function isUUID (ctx) {
  *
  * @param {ValidatorContext} ctx Config Validator context instance
  */
-export function isArray (ctx) {
+export function toArray (ctx) {
   const { value } = ctx
-  if (typeof value === 'string') {
+  if (ctx.hasValue()) {
     ctx.value = value.split(',')
   }
 }
@@ -198,15 +280,14 @@ export function isArray (ctx) {
  *
  * @param {ValidatorContext} ctx Config Validator context instance
  */
-export function isNumber (ctx) {
-  const { value, defaultValue } = ctx
-  if (typeof value === 'string') {
+export function toNumber (ctx) {
+  const { value } = ctx
+  if (ctx.hasValue()) {
     // Use Number() cast instead of parseInt() because Number() is more strict on string values.
     const intValue = Number(value)
 
     if (Number.isNaN(intValue)) {
-      ctx.value = defaultValue
-      ctx.warnStructured('number', defaultValue)
+      ctx.warnSetDefault({ type: 'number' })
     } else {
       ctx.value = intValue
     }
@@ -221,9 +302,9 @@ export function isNumber (ctx) {
  *
  * @param {ValidatorContext} ctx Config Validator context instance
  */
-export function isBoolean (ctx) {
+export function toBoolean (ctx) {
   const { value } = ctx
-  if (typeof value === 'string') {
+  if (ctx.hasValue()) {
     ctx.value = value.toLowerCase() === 'true'
   }
 }
@@ -237,19 +318,17 @@ export function isBoolean (ctx) {
  *
  * @param {ValidatorContext} ctx Config Validator context instance
  */
-export function isStrictBoolean (ctx) {
-  const { value, defaultValue } = ctx
-  if (typeof value === 'string') {
+export function toStrictBoolean (ctx) {
+  const { value } = ctx
+  if (ctx.hasValue()) {
     if (['true', 'false'].includes(value.toLowerCase())) {
-      isBoolean(ctx)
+      toBoolean(ctx)
     } else {
       // if string value is not explicitly 'true' or 'false', throw warning, then revert to default value
-      ctx.value = defaultValue
-      ctx.warnStructured(
-        'boolean-like string',
-        defaultValue,
-        "A case insensitive string matching 'true' or 'false'.",
-      )
+      ctx.warnSetDefault({
+        type: 'boolean',
+        expected: "Value of 'true' or 'false'.",
+      })
     }
   }
 }
@@ -261,7 +340,7 @@ export function ensureValidConfig () {
   console.error(`${configErrors} config errors.`)
   console.warn(`${configWarnings} config warnings.`)
   if (configErrors > 0) {
-    console.error('FATAL CONFIGURATION PROBLEMS DETECTED, EXITING')
+    console.error('FATAL CONFIGURATION PROBLEMS DETECTED, EXITING...')
     process.abort()
   }
 }

--- a/src/helpers/ConfigValidators.mjs
+++ b/src/helpers/ConfigValidators.mjs
@@ -1,0 +1,267 @@
+import { IRCChannel, UUID } from './Validators'
+
+
+
+
+
+let configErrors = 0
+let configWarnings = 0
+
+
+/**
+ * Provides a context object for validator functions assigned to a config value.
+ * Also responsible for running the provided validation functions.
+ */
+class ValidatorContext {
+  property = ''
+  value = undefined
+  defaultValue = undefined
+
+
+  /**
+   * @param {string} property The environment variable name
+   * @param {Function[]} validations array of validation functions to run
+   * @param {*} defaultValue default value to be provided for this, if any
+   */
+  constructor (property, validations = [], defaultValue) {
+    this.value = process.env[property] ?? defaultValue
+    this.property = property
+    this.defaultValue = defaultValue
+
+    if (typeof defaultValue !== 'undefined' && this.value === defaultValue) {
+      // Don't waste time validating defined default values
+      return
+    }
+
+    validations.forEach((validator) => {
+      validator.call(this, this)
+    })
+  }
+
+  /**
+   * Formats an array of message lines.
+   *
+   * @param {string[]} messages A list of messages to display. Each string representing a line in the message.
+   * @returns {string[]}
+   */
+  _getMessage (messages) {
+    return messages.reduce((acc, line) => {
+      if (line) {
+        acc.push(`\n    ${line}`)
+      }
+      return acc
+    }, [])
+  }
+
+  /**
+   * Displays an unrecoverable error with the given message.
+   *
+   * @param {...string} messages A list of messages to display. Each string representing a line in the message.
+   */
+  error (...messages) {
+    console.error('FATAL ERROR', ...this._getMessage(messages))
+    configErrors += 1
+  }
+
+  /**
+   * Displays a warning with the given message.
+   *
+   * @param {...string} messages A list of messages to display. Each string representing a line in the message.
+   */
+  warn (...messages) {
+    console.warn('WARNING:', ...this._getMessage(messages))
+    configWarnings += 1
+  }
+
+  /**
+   * Displays a warning which follows a standard message structure.
+   *
+   * @param {string} validType A string representing the expected valid type of value.
+   * @param {string?} nextValue The value that will be used instead of the provided value.
+   * @param {string?} expectedExplainer A sentance that explains what value was expected.
+   */
+  warnStructured (validType, nextValue, expectedExplainer) {
+    this.warn([
+      `Config parameter '${this.property}' was not provided a valid ${validType}.`,
+      expectedExplainer && `Expected: ${expectedExplainer}`,
+      nextValue && `Parameter will become: '${nextValue}'.`,
+    ])
+  }
+}
+
+
+
+/**
+ * Get and validate an environment variable
+ *
+ * @param {string} property The environment variable name
+ * @param {Function[]} validations array of validation functions to run
+ * @param {*} defaultValue default value to be provided for this, if any
+ * @returns {*|undefined}
+ */
+export function optional (property, validations = [], defaultValue = undefined) {
+  return (new ValidatorContext(property, validations, defaultValue)).value
+}
+
+/**
+ * Set a recommended config environment variable. This setting will cause a warning if value is `undefined`.
+ *
+ * @param {string} property The environment variable name
+ * @param {Function[]} validations array of validation functions to run
+ * @param {*} defaultValue default value to be provided for this, if any
+ * @returns {*|undefined}
+ */
+export function recommended (property, validations = [], defaultValue = undefined) {
+  const isRecommend = (ctx) => {
+    if (typeof ctx.value === 'undefined') {
+      ctx.warn(
+        `Recommended config parameter '${ctx.property}' is not configured.`,
+        'Functionality will be limited and/or unstable.',
+      )
+    }
+  }
+
+  return optional(property, [...validations, isRecommend], defaultValue)
+}
+
+/**
+ * Require and validate a config environment variable. This setting will cause a fatal error if value is `undefined`.
+ *
+ * @param {string} property The environment variable name
+ * @param {Function[]} validations array of validation functions to run
+ * @param {*} defaultValue default value to be provided for this, if any
+ * @returns {*|undefined}
+ */
+export function required (property, validations = [], defaultValue = undefined) {
+  const isRequired = (ctx) => {
+    if (typeof ctx.value === 'undefined') {
+      ctx.error(
+        `Required config parameter '${ctx.property}' is not configured.`,
+        'Parameter must be configured to continue!',
+      )
+    }
+  }
+
+  return optional(property, [...validations, isRequired], defaultValue)
+}
+
+
+/**
+ * Config validator that ensures the value is a valid IRC channel name as defined by RFC1459.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isIrcChannel (ctx) {
+  const { value, defaultValue } = ctx
+  if (typeof value === 'string' && !IRCChannel.test(value)) {
+    ctx.value = defaultValue
+    ctx.warnStructured(
+      'IRC Channel name',
+      defaultValue,
+      "A string that begins with '#' or '&', and contains no whitespaces or commas.",
+    )
+  }
+}
+
+/**
+ * Config validator that ensures the value is a valid UUID string.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isUUID (ctx) {
+  const { value, defaultValue } = ctx
+  if (typeof value === 'string' && !UUID.test(value)) {
+    ctx.value = defaultValue
+    ctx.warnStructured(
+      'UUID',
+      defaultValue,
+      "A string in the format of 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.",
+    )
+  }
+}
+
+
+/**
+ * Config validator that splits a string by the array delimiter ','. Does not validate further.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isArray (ctx) {
+  const { value } = ctx
+  if (typeof value === 'string') {
+    ctx.value = value.split(',')
+  }
+}
+
+/**
+ * Config validator which converts a string to a number value.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isNumber (ctx) {
+  const { value, defaultValue } = ctx
+  if (typeof value === 'string') {
+    // Use Number() cast instead of parseInt() because Number() is more strict on string values.
+    const intValue = Number(value)
+
+    if (Number.isNaN(intValue)) {
+      ctx.value = defaultValue
+      ctx.warnStructured('number', defaultValue)
+    } else {
+      ctx.value = intValue
+    }
+  }
+}
+
+/**
+ * Config validator which converts a string to a boolean value.
+ *
+ * * sets `true` if `value` is `'true'` (case-insensitive).
+ * * Otherwise, sets `false`
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isBoolean (ctx) {
+  const { value } = ctx
+  if (typeof value === 'string') {
+    ctx.value = value.toLowerCase() === 'true'
+  }
+}
+
+/**
+ * Config validator which converts a string to a boolean value.
+ *
+ * * sets `true` if `value` is `'true'` (case-insensitive).
+ * * sets `false` if `value` is `'false'` (case-insensitive).
+ * * Otherwise, a warning is thrown and the value is set to it's default value.
+ *
+ * @param {ValidatorContext} ctx Config Validator context instance
+ */
+export function isStrictBoolean (ctx) {
+  const { value, defaultValue } = ctx
+  if (typeof value === 'string') {
+    if (['true', 'false'].includes(value.toLowerCase())) {
+      isBoolean(ctx)
+    } else {
+      // if string value is not explicitly 'true' or 'false', throw warning, then revert to default value
+      ctx.value = defaultValue
+      ctx.warnStructured(
+        'boolean-like string',
+        defaultValue,
+        "A case insensitive string matching 'true' or 'false'.",
+      )
+    }
+  }
+}
+
+/**
+ * Emits meta-information about config errors and warnings, then aborts the process if errors are present.
+ */
+export function ensureValidConfig () {
+  console.error(`${configErrors} config errors.`)
+  console.warn(`${configWarnings} config warnings.`)
+  if (configErrors > 0) {
+    console.error('FATAL CONFIGURATION PROBLEMS DETECTED, EXITING')
+    process.abort()
+  }
+}

--- a/src/helpers/Validators.mjs
+++ b/src/helpers/Validators.mjs
@@ -15,6 +15,8 @@ const requiredQuoteFields = [
 
 export const IRCVirtualHost = /^[a-z][a-z0-9.]{3,64}$/u
 export const IRCNickname = /^[A-Za-z_\\`\[\]{}]([A-Za-z0-9_\\`\[\]{}\-|]{1,29})?$/u
+// eslint-disable-next-line no-control-regex -- RFC1459 compliant channel names must not contain \x07 (BELL)
+export const IRCChannel = /^[&#][^\x07,\s]{1,200}$/u
 export const languageCode = /^[a-z]{2}-[A-Z]{2}$/u
 export const stripeUserId = /cus_[A-Za-z0-9]{14}$/u
 

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -380,10 +380,6 @@ export default class Users extends APIResource {
       userId: ctx.params.id,
     })
 
-    user.changed('updatedAt', true)
-    await user.save()
-
-
     Event.broadcast('fuelrats.userupdate', ctx.state.user, user.id, {})
     const query = new DatabaseQuery({ connection: ctx })
     const result = await User.findOne({

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -127,7 +127,7 @@ export default class Users extends APIResource {
   @websocket('users', 'image', 'read')
   @parameters('id')
   async image (ctx, next) {
-    const avatar = await Avatar.scope('data').findOne({
+    const avatar = await Avatar.scope('imageData').findOne({
       where: {
         userId: ctx.params.id,
       },
@@ -346,7 +346,7 @@ export default class Users extends APIResource {
    * @returns {Promise<DatabaseDocument>} an updated user if the request is successful
    */
   @POST('/users/:id/image')
-  @websocket('users', 'image')
+  @websocket('users', 'image', 'create')
   @parameters('id')
   @authenticated
   async setimage (ctx) {

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -381,6 +381,10 @@ export default class Users extends APIResource {
       userId: ctx.params.id,
     })
 
+    user.changed('updatedAt', true)
+    await user.save()
+
+
     Event.broadcast('fuelrats.userupdate', ctx.state.user, user.id, {})
     const query = new DatabaseQuery({ connection: ctx })
     const result = await User.findOne({

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -346,7 +346,6 @@ export default class Users extends APIResource {
    * @returns {Promise<DatabaseDocument>} an updated user if the request is successful
    */
   @POST('/users/:id/image')
-  @websocket('users', 'image', 'create')
   @parameters('id')
   @authenticated
   async setimage (ctx) {

--- a/src/view/AvatarView.mjs
+++ b/src/view/AvatarView.mjs
@@ -29,8 +29,7 @@ export default class AvatarView extends DatabaseView {
    */
   get links () {
     return {
-      self: `${config.server.externalUrl}/${this.self}`,
-      image: `${config.server.externalUrl}/users/${this.object.userId}/image`,
+      self: `${config.server.externalUrl}/users/${this.object.userId}/image`,
     }
   }
 

--- a/src/view/AvatarView.mjs
+++ b/src/view/AvatarView.mjs
@@ -1,0 +1,83 @@
+import config from '../config'
+import DatabaseView from './DatabaseView'
+import UserView from './UserView'
+import { ReadPermission } from './View'
+
+/**
+ * Get JSONAPI view for a User
+ */
+export default class AvatarView extends DatabaseView {
+  /**
+   * @inheritdoc
+   */
+  static get type () {
+    return 'avatars'
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get attributes () {
+    return class {
+      static createdAt
+      static updatedAt
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get links () {
+    return {
+      self: `${config.server.externalUrl}/${this.self}`,
+      image: `${config.server.externalUrl}/users/${this.object.userId}/image`,
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get defaultReadPermission () {
+    return ReadPermission.all
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get isSelf () {
+    if (this.query.connection.state.user && this.object.userId === this.query.connection.state.user.id) {
+      return this.query.connection.state.permissions.includes('users.read.me')
+    }
+    return false
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get isGroup () {
+    return this.query.connection.state.permissions.includes('users.read')
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get isInternal () {
+    return this.query.connection.state.permissions.includes('users.internal')
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get relationships () {
+    return {
+      user: UserView,
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get includes () {
+    return ['user']
+  }
+}

--- a/src/view/UserView.mjs
+++ b/src/view/UserView.mjs
@@ -1,3 +1,5 @@
+import config from '../config'
+import AvatarView from './AvatarView'
 import ClientView from './ClientView'
 import DatabaseView from './DatabaseView'
 import DecalView from './DecalView'
@@ -29,7 +31,6 @@ export default class UserView extends DatabaseView {
       static suspended = ReadPermission.group
       static stripeId = ReadPermission.group
       static frontierId = ReadPermission.group
-      static image
       static createdAt
       static updatedAt
       static deletedAt = ReadPermission.internal
@@ -72,6 +73,7 @@ export default class UserView extends DatabaseView {
    */
   get relationships () {
     return {
+      avatar: AvatarView,
       rats: RatView,
       nicknames: NicknameView,
       displayRat: RatView,
@@ -80,6 +82,22 @@ export default class UserView extends DatabaseView {
       epics: EpicView,
       decals: DecalView,
     }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  getRelationLink (relation) {
+    const links = {
+      self: `${config.server.externalUrl}/${this.self}/relationships/${relation}`,
+      related: `${config.server.externalUrl}/${this.self}/${relation}`,
+    }
+
+    if (relation === 'avatar') {
+      links.image = `${config.server.externalUrl}/${this.self}/image`
+    }
+
+    return links
   }
 
   /**
@@ -101,6 +119,15 @@ export default class UserView extends DatabaseView {
    * @inheritdoc
    */
   get includes () {
-    return ['rats', 'displayRat', 'groups', 'clients', 'nicknames', 'epics', 'decals']
+    return [
+      'avatar',
+      'rats',
+      'displayRat',
+      'groups',
+      'clients',
+      'nicknames',
+      'epics',
+      'decals',
+    ]
   }
 }

--- a/src/view/UserView.mjs
+++ b/src/view/UserView.mjs
@@ -88,16 +88,15 @@ export default class UserView extends DatabaseView {
    * @inheritdoc
    */
   getRelationLink (relation) {
-    const links = {
-      self: `${config.server.externalUrl}/${this.self}/relationships/${relation}`,
-      related: `${config.server.externalUrl}/${this.self}/${relation}`,
-    }
+    switch (relation) {
+      case 'avatar':
+        return {
+          self: `${config.server.externalUrl}/${this.self}/image`,
+        }
 
-    if (relation === 'avatar') {
-      links.image = `${config.server.externalUrl}/${this.self}/image`
+      default:
+        return super.getRelationLink(relation)
     }
-
-    return links
   }
 
   /**


### PR DESCRIPTION
### Add `avatars` Resource

* Introduce `AvatarView` and adjust `UserView` along with `Avatar` and `User` data model to accommodate.
* `UserView` now presents an avatar as a relationship, solving the issue of `attributes.image` being `false` when the `'norelations'` scope is in use. This was forcing avatars to revert back to default on the front end.
* `user.attributes.image` no longer exists. Consumers of the Avatar API (should only be fuelrats.com) should look to the existence of an avatar relationship on the user instead.
* `Avatar` model's scopes have been changed. `defaultScope` now includes all attributes except image, and `data` scope has been renamed to `imageData` to better represent it's purpose.


### Re-implement config validation (for fun!)

* Introduce new config validators for specific config values.
* Some validators perform type conversions, and others are value validators that can throw errors.

As for why I changed config validation, I originally did it to introduce type conversion to an array for `FRAPI_WHITELIST`. The only reason why this feature works as expected now is because `string.prototype.includes()` produces the same result as `array.prototype.includes()` in this use case. The expectation here, however, is that the value is an array. This is also true for numbers and bools from what I can tell so I have added converters for those as well. Some regex-based validators have been introduced just to ensure specific string values are valid, and URL properties that are used as "base urls" for links are sanity checked now.

I'm considering a full package for this kind of thing in the future to be shared between us. Something that can pull from both `process.env` and `process.argv`, and provide even better validation options.