### PR TITLE
Bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "git-rev-promises": "^1.1.0",
     "gulp-cli": "^2.2.0",
     "i18next": "^19.0.1",
-    "join-js": "xlexi/joinjs",
     "knex": "~2.4.2",
     "koa": "^2.11.0",
     "koa-body": "^4.1.1",

--- a/src/classes/Anope.mjs
+++ b/src/classes/Anope.mjs
@@ -453,7 +453,6 @@ class Anope {
           KILLPROTECT: 1,
           MEMO_RECEIVE: 1,
           MEMO_SIGNON: 1,
-          NS_NO_EXPIRE: 1,
           NS_PRIVATE: 1,
           NS_SECURE: 1,
           display: nick,
@@ -472,6 +471,7 @@ class Anope {
         vhost_creator: 'API',
         vhost_time: createdUnixTime,
         vhost_host: vhost,
+        NS_NO_EXPIRE: 1,
       }).into('anope_db_NickAlias')
 
       await transaction.commit()

--- a/src/helpers/Validators.mjs
+++ b/src/helpers/Validators.mjs
@@ -4,7 +4,7 @@ import { UnprocessableEntityAPIError } from '../classes/APIError'
 import RegexLiteral from './RegexLiteral'
 
 
-const forbiddenCMDRNameComponents = ['[pc]', '[xb]', '[ps]', 'CMDR']
+const forbiddenCMDRNameComponents = ['[pc]', '[xb]', '[ps]', 'cmdr']
 const requiredQuoteFields = [
   'message',
   'author',

--- a/src/routes/APIResource.mjs
+++ b/src/routes/APIResource.mjs
@@ -360,7 +360,7 @@ export default class APIResource extends API {
         return undefined
       }
 
-      if (!Reflect.apply(changeRelationship.hasPermission, this, [ctx, entity, relationship.id])) {
+      if (!Reflect.apply(changeRelationship.hasPermission, this, [ctx, entity, data.id])) {
         throw new ForbiddenAPIError({ pointer: '/data' })
       }
       return changeRelationship.patch({ entity, id: data.id, ctx, transaction })

--- a/src/routes/Clients.mjs
+++ b/src/routes/Clients.mjs
@@ -201,8 +201,8 @@ export default class Clients extends APIResource {
     if (relationship === 'user') {
       return {
         many: false,
-        hasPermission (connection, entity, id) {
-          return (!entity.userId && id === connection.state.user.id) || Permission.granted({
+        hasPermission (connection) {
+          return Permission.granted({
             permissions: ['clients.write'],
             connection,
           })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,7 +2462,6 @@ __metadata:
     gulp-cli: ^2.2.0
     i18next: ^19.0.1
     jest: ^24.9.0
-    join-js: xlexi/joinjs
     jsdoc: ^3.6.7
     jsonapi-validator: ^3.0.5
     knex: ~2.4.2
@@ -6752,13 +6751,6 @@ __metadata:
   bin:
     jest: ./bin/jest.js
   checksum: 7bc61d47f94b18d52f354d785a9743883045222d0f1309a1131f0843479bdf8d98de1d62b9f519a562e99f883c51bd8af6a52f9e5a19596dae97d835abbc2cff
-  languageName: node
-  linkType: hard
-
-join-js@xlexi/joinjs:
-  version: 0.0.0-development
-  resolution: "join-js@https://github.com/xlexi/joinjs.git#commit=d159421c5179c27b076bf7b19dc3276bd85136b7"
-  checksum: 8cf321d4e5fedb17c3b0c7b9a26da5b6a865068e5365470b6c2ea0abf5cd560e1a2d2b20d1a142b3d510efd2cb3121ce111dc9f4b27a6f8ad3c168e771e8ea50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes users without `rats.write` being unable to change their display rat due to their rat ids being compared with `undefined` and not the new id.
Fixes "CMDR" not correctly being forbidden in names due to it being in uppercase.