### PR TITLE
fix(errors): log FK and unique constraint errors with detail

### DIFF
--- a/src/Documents/ErrorDocument.mjs
+++ b/src/Documents/ErrorDocument.mjs
@@ -61,13 +61,38 @@ class ErrorDocument extends Document {
           }))
           break
 
-        case (error.name === 'SequelizeForeignKeyConstraintError'):
+        case (error.name === 'SequelizeForeignKeyConstraintError'): {
+          const fkFields = Array.isArray(error.fields) ? error.fields : Object.keys(error.fields ?? {})
+          // The underlying pg error spells out which key was missing or still referenced,
+          // e.g. `Key (ratId)=(...) is not present in table "Rats".`
+          const fkDetail = error.parent?.detail ?? error.message
+          logger.error({
+            GELF: true,
+            _event: 'sequelize_foreign_key_error',
+            _error_message: error.message,
+            _constraint: error.index ?? error.parent?.constraint,
+            _table: error.table ?? error.parent?.table,
+            _fields: fkFields.join(', '),
+            _detail: fkDetail,
+          }, `Sequelize foreign key constraint error: ${fkDetail}`)
+          logger.error(`Failing SQL: ${error.sql}`)
           errorAcc.push(new UnprocessableEntityAPIError({
             pointer: '/data/id',
+            detail: fkDetail,
           }))
           break
+        }
 
         case (error.name === 'SequelizeUniqueConstraintError'):
+          logger.error({
+            GELF: true,
+            _event: 'sequelize_unique_constraint_error',
+            _error_message: error.message,
+            _constraint: error.parent?.constraint,
+            _table: error.parent?.table,
+            _fields: Object.keys(error.fields ?? {}).join(', '),
+            _detail: error.parent?.detail,
+          }, `Sequelize unique constraint error: ${error.parent?.detail ?? error.message}`)
           errorAcc.push(...error.errors.map((validationError) => {
             const pointer = validationError.path === 'id' ? '/data/id' : `/data/attributes/${validationError.path}`
             return new ConflictAPIError({


### PR DESCRIPTION
Task #5 from the incident review. During the phantom-rat incident, a foreign-key violation surfaced as an **opaque 422 with an empty error message and nothing in the logs** — the `SequelizeForeignKeyConstraintError` branch of `ErrorDocument` returned `UnprocessableEntityAPIError({ pointer: "/data/id" })` with no `detail` and, unlike the `SequelizeDatabaseError` branch right next to it, logged nothing at all. That is why it took a live DB investigation to discover a rat had been deleted while still referenced by a rescue.

## Change (`src/Documents/ErrorDocument.mjs`)
- **Foreign-key errors:** log a GELF record with the constraint name, table, fields and Postgres's own `parent.detail` (e.g. `Key (ratId)=(...) is not present in table "Rats".`) + the failing SQL, and surface that `detail` on the returned 422 so clients get an actionable message instead of a blank one.
- **Unique-constraint errors:** add the same structured logging (they were also silent). Client response unchanged (still per-field `ConflictAPIError`).

Property access is defensive (optional chaining + `error.message` fallback), verified against the installed Sequelize error classes (`table`/`fields`/`index` on the FK error, `parent`/`sql` on the base `DatabaseError`).

## Verification
`eslint` clean on the changed file. (No unit tests exist for `ErrorDocument`; the route tests are DB-backed integration tests out of scope here.)