### PR TITLE
Release: rat/user delete events + constraint error logging

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@ export default [
       'src/model/',
       'data/',
       'tools/',
+      'static/scalar.js',
     ],
   },
 ]

--- a/scripts/openapi-post-process.mjs
+++ b/scripts/openapi-post-process.mjs
@@ -9,8 +9,6 @@ import { join } from 'path'
 
 const BUNDLED = join(import.meta.dir, '..', 'docs', 'openapi', 'bundled.yaml')
 
-const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete']
-
 /**
  * Generate an operationId from method + path
  * e.g. GET /users/{id}/passkeys → getUsers_id_passkeys
@@ -44,13 +42,13 @@ async function main () {
     const line = lines[i]
 
     // Detect path: "  /some/path:" at 2-space indent
-    const pathMatch = line.match(/^  (\/[^:]+):$/)
+    const pathMatch = line.match(/^ {2}(\/[^:]+):$/)
     if (pathMatch) {
       currentPath = pathMatch[1]
     }
 
     // Detect method: "    get:" at 4-space indent
-    const methodMatch = line.match(/^    (get|post|put|patch|delete):$/)
+    const methodMatch = line.match(/^ {4}(get|post|put|patch|delete):$/)
     if (methodMatch && currentPath) {
       const method = methodMatch[1]
       output.push(line)
@@ -63,7 +61,7 @@ async function main () {
           break
         }
         // Stop checking at next key at same or lower indent
-        if (lines[j].match(/^    \w/) || lines[j].match(/^  \//)) {
+        if (lines[j].match(/^ {4}\w/) || lines[j].match(/^ {2}\//)) {
           break
         }
       }

--- a/src/Documents/ErrorDocument.mjs
+++ b/src/Documents/ErrorDocument.mjs
@@ -61,13 +61,38 @@ class ErrorDocument extends Document {
           }))
           break
 
-        case (error.name === 'SequelizeForeignKeyConstraintError'):
+        case (error.name === 'SequelizeForeignKeyConstraintError'): {
+          const fkFields = Array.isArray(error.fields) ? error.fields : Object.keys(error.fields ?? {})
+          // The underlying pg error spells out which key was missing or still referenced,
+          // e.g. `Key (ratId)=(...) is not present in table "Rats".`
+          const fkDetail = error.parent?.detail ?? error.message
+          logger.error({
+            GELF: true,
+            _event: 'sequelize_foreign_key_error',
+            _error_message: error.message,
+            _constraint: error.index ?? error.parent?.constraint,
+            _table: error.table ?? error.parent?.table,
+            _fields: fkFields.join(', '),
+            _detail: fkDetail,
+          }, `Sequelize foreign key constraint error: ${fkDetail}`)
+          logger.error(`Failing SQL: ${error.sql}`)
           errorAcc.push(new UnprocessableEntityAPIError({
             pointer: '/data/id',
+            detail: fkDetail,
           }))
           break
+        }
 
         case (error.name === 'SequelizeUniqueConstraintError'):
+          logger.error({
+            GELF: true,
+            _event: 'sequelize_unique_constraint_error',
+            _error_message: error.message,
+            _constraint: error.parent?.constraint,
+            _table: error.parent?.table,
+            _fields: Object.keys(error.fields ?? {}).join(', '),
+            _detail: error.parent?.detail,
+          }, `Sequelize unique constraint error: ${error.parent?.detail ?? error.message}`)
           errorAcc.push(...error.errors.map((validationError) => {
             const pointer = validationError.path === 'id' ? '/data/id' : `/data/attributes/${validationError.path}`
             return new ConflictAPIError({

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -231,7 +231,7 @@ honoApp.get('/', (c) => {
   return c.html(html)
 })
 
-honoApp.get('/static/scalar.js', async (c) => {
+honoApp.get('/static/scalar.js', async (_c) => {
   const fs = await import('fs/promises')
   const path = await import('path')
   const filePath = path.resolve('static/scalar.js')

--- a/src/routes/Rats.mjs
+++ b/src/routes/Rats.mjs
@@ -166,6 +166,10 @@ export default class Rats extends APIResource {
         _rescue_count: rat.rescues?.length ?? 0,
         _first_limpet_count: rat.firstLimpet?.length ?? 0,
       }, `Rat deleted: ${rat.name} (${rat.id}) by user ${ctx.state.user.id}`)
+
+      // Notify subscribers that the owner's rats changed so clients (e.g. the dispatch
+      // board) can drop the now-deleted rat. Mirrors the create/update broadcasts above.
+      Event.broadcast('fuelrats.userupdate', ctx.state.user, rat.userId, {})
     }
 
     ctx.response.status = StatusCode.noContent

--- a/src/routes/Users.mjs
+++ b/src/routes/Users.mjs
@@ -26,6 +26,7 @@ import {
   BadRequestAPIError,
   InternalServerError,
   ImATeapotAPIError,
+  UnprocessableEntityAPIError,
 } from '../classes/APIError'
 import Authentication from '../classes/Authentication'
 import Event from '../classes/Event'
@@ -673,6 +674,10 @@ export default class Users extends APIResource {
     })
 
     await Anope.deleteAccount(user.email)
+
+    // Notify subscribers that this account (and its now-deleted rats) is gone so clients
+    // can reconcile any cached references.
+    Event.broadcast('fuelrats.userupdate', ctx.state.user, user.id, {})
 
     ctx.response.status = StatusCode.noContent
     return true


### PR DESCRIPTION
Promote `develop` → `main` to deploy to production. Delta is exactly the two changes already merged and soaking on `fr-api-dev`:

- **#726** — broadcast `fuelrats.userupdate` on rat/user deletion (root-cause fix for stale client references).
- **#727** — log FK/unique constraint errors with detail (no more empty-message 422s).

Both are pure code changes — **no DB migration**. CI-green, and running on dev since ~09:49/10:27 UTC with no issues. Merging triggers the Deploy workflow (build `:main` + `docker service update fr-api_api`).