### PR TITLE
fix(nicknames): prevent and heal orphaned Anope nick aliases

### DIFF
--- a/src/classes/Anope.mjs
+++ b/src/classes/Anope.mjs
@@ -376,6 +376,8 @@ class Anope {
         LEFT JOIN anope_db_NickCore ON anope_db_NickCore.display = anope_db_NickAlias.nc
         WHERE
             lower(anope_db_NickAlias.nick) = lower(?)
+        ORDER BY anope_db_NickCore.id IS NULL
+        LIMIT 1
     `, [nickname])
     if (!account) {
       return undefined
@@ -580,15 +582,48 @@ class Anope {
    * @param {string} nickname the nickname to remove
    * @returns {Promise<undefined>} resolves a promise when completed successfully
    */
-  static removeNickname (nickname) {
+  static async removeNickname (nickname) {
     if (!config.anope.database) {
       return undefined
     }
 
-    return mysql.raw(`
+    const alias = await mysql('anope_db_NickAlias')
+      .whereRaw('lower(nick) = lower(?)', [nickname])
+      .first('nc')
+
+    await mysql.raw(`
       DELETE FROM anope_db_NickAlias
       WHERE  lower(nick) = lower(?)
     `, [nickname])
+
+    // If that was the group's last alias, remove the now-orphaned account so it can't
+    // resurface as a nick with no listable aliases (and no whois-resolvable account).
+    if (alias?.nc) {
+      const remaining = await mysql('anope_db_NickAlias')
+        .where({ nc: alias.nc })
+        .count({ count: '*' })
+        .first()
+
+      if (Number(remaining?.count ?? 0) === 0) {
+        await mysql('anope_db_NickCore').where({ display: alias.nc }).del()
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Remove a nickname from the Anope database by its Anope alias id
+   * @param {number} anopeId the Anope NickAlias id to remove
+   * @returns {Promise<undefined>} resolves a promise when completed successfully
+   */
+  static async removeNicknameByAnopeId (anopeId) {
+    if (!config.anope.database) {
+      return undefined
+    }
+
+    await mysql('anope_db_NickAlias').where({ id: anopeId }).del()
+    return undefined
   }
 
   /**
@@ -650,7 +685,7 @@ class Anope {
 
       const existingNickname = await Anope.findNickname(nick)
       if (existingNickname) {
-        if (existingNickname.email.toLowerCase() === email.toLowerCase()) {
+        if (existingNickname.email?.toLowerCase() === email.toLowerCase()) {
           return existingNickname
         }
         throw new ConflictAPIError({
@@ -677,7 +712,10 @@ class Anope {
         }).into('anope_db_NickCore')
       }
 
-      const accountNick = user ? user.nc : nick
+      // Group the new alias under the account's display nick. `user.nc` comes from the
+      // NickCore→NickAlias left join and is null when the account has no aliases yet,
+      // which would create an orphaned alias (nc = NULL); the display is always the group key.
+      const accountNick = user ? (user.display ?? user.nc) : nick
 
       const insertedNickname = await transaction.insert({
         nc: accountNick,

--- a/src/routes/Nicknames.mjs
+++ b/src/routes/Nicknames.mjs
@@ -115,7 +115,13 @@ export default class Nickname extends APIResource {
 
     const existingNick = await Anope.findNickname(nick)
     if (existingNick) {
-      throw new ConflictAPIError({ pointer: '/data/attributes/nick' })
+      // A dangling alias with no backing account (email is null) is not a real
+      // registration — it can't be listed or resolved via whois. Rather than block the
+      // nick forever, clear the stale row (by its exact id) and continue registering.
+      if (existingNick.email) {
+        throw new ConflictAPIError({ pointer: '/data/attributes/nick' })
+      }
+      await Anope.removeNicknameByAnopeId(existingNick.anopeId)
     }
 
     const encryptedPassword = `bcrypt:${targetUser.password}`


### PR DESCRIPTION
## Problem

Registering an IRC nickname could leave an **orphaned `anope_db_NickAlias` row**, wedging the nick into an unusable state: `POST /nicknames` returns **409 Conflict**, yet the web app shows no nicks and `!whois <nick>` reports no account.

Root cause is that the nick system is backed directly by Anope's two tables joined on `NickCore.display = NickAlias.nc`, and several paths let an alias exist without a valid backing account:

- **`findNickname`** (the 409 gate) `LEFT JOIN`s and matches on the alias alone, so it sees a dangling alias.
- **`getAccount`** / whois are driven from `NickCore`, so a missing/empty account shows nothing.

Discovered via a real ticket (CMDR `arckoor`): a valid alias (`nc=arckoor` → account) coexisted with a duplicate orphan alias (`nc=NULL`). The orphan tripped the 409 and blanked the web listing.

## How the orphan got created

`addNewUser` sets the new alias's group with:

```js
const accountNick = user ? user.nc : nick
```

`user` comes from `getAccount(email)`, a `NickCore LEFT JOIN NickAlias`. When the account exists but has **no aliases yet**, the join yields `nc = NULL`, so the alias is inserted with **`nc = NULL`** — an orphan. Empty accounts arise because `removeNickname` deleted aliases without ever removing the emptied `NickCore`.

## Changes (application logic only — no DB schema changes)

Anope owns the schema, so this fixes everything in the API:

1. **`addNewUser`** — group new aliases under the account's **`display`** (the real group key), never the join-nullable `nc`. Stops `nc=NULL` orphans at the source.
2. **`removeNickname`** — when the group's last alias is removed, delete the now-orphaned `NickCore`, so an emptied account can't linger and later seed a null-group alias.
3. **`findNickname`** — `ORDER BY NickCore.id IS NULL` so an account-backed alias wins over a co-named orphan; the 409 gate and `delete`/`setDisplay` then act on the real registration.
4. **`POST /nicknames`** — a dangling alias with no backing account (`email` is null) is not a real conflict: remove the stale row **by its exact id** (`removeNicknameByAnopeId`) and continue, instead of blocking the nick permanently. Deleting by id (not by `lower(nick)`) avoids collateral damage to a valid co-named alias.

## Verification

- `eslint` clean on both files.
- No test suite exists in the repo (`test/` is empty; these paths require a live Anope MySQL), so changes were verified by lint + review against the live schema/data that reproduced the ticket.
- The already-broken `arckoor` row was cleaned out-of-band; these changes prevent recurrence and let a future occurrence self-heal on the next registration attempt.