### PR TITLE
release: anope orphaned-nickname fix to prod

### DIFF
--- a/src/classes/Anope.mjs
+++ b/src/classes/Anope.mjs
@@ -376,6 +376,8 @@ class Anope {
         LEFT JOIN anope_db_NickCore ON anope_db_NickCore.display = anope_db_NickAlias.nc
         WHERE
             lower(anope_db_NickAlias.nick) = lower(?)
+        ORDER BY anope_db_NickCore.id IS NULL
+        LIMIT 1
     `, [nickname])
     if (!account) {
       return undefined
@@ -580,15 +582,48 @@ class Anope {
    * @param {string} nickname the nickname to remove
    * @returns {Promise<undefined>} resolves a promise when completed successfully
    */
-  static removeNickname (nickname) {
+  static async removeNickname (nickname) {
     if (!config.anope.database) {
       return undefined
     }
 
-    return mysql.raw(`
+    const alias = await mysql('anope_db_NickAlias')
+      .whereRaw('lower(nick) = lower(?)', [nickname])
+      .first('nc')
+
+    await mysql.raw(`
       DELETE FROM anope_db_NickAlias
       WHERE  lower(nick) = lower(?)
     `, [nickname])
+
+    // If that was the group's last alias, remove the now-orphaned account so it can't
+    // resurface as a nick with no listable aliases (and no whois-resolvable account).
+    if (alias?.nc) {
+      const remaining = await mysql('anope_db_NickAlias')
+        .where({ nc: alias.nc })
+        .count({ count: '*' })
+        .first()
+
+      if (Number(remaining?.count ?? 0) === 0) {
+        await mysql('anope_db_NickCore').where({ display: alias.nc }).del()
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Remove a nickname from the Anope database by its Anope alias id
+   * @param {number} anopeId the Anope NickAlias id to remove
+   * @returns {Promise<undefined>} resolves a promise when completed successfully
+   */
+  static async removeNicknameByAnopeId (anopeId) {
+    if (!config.anope.database) {
+      return undefined
+    }
+
+    await mysql('anope_db_NickAlias').where({ id: anopeId }).del()
+    return undefined
   }
 
   /**
@@ -650,7 +685,7 @@ class Anope {
 
       const existingNickname = await Anope.findNickname(nick)
       if (existingNickname) {
-        if (existingNickname.email.toLowerCase() === email.toLowerCase()) {
+        if (existingNickname.email?.toLowerCase() === email.toLowerCase()) {
           return existingNickname
         }
         throw new ConflictAPIError({
@@ -677,7 +712,10 @@ class Anope {
         }).into('anope_db_NickCore')
       }
 
-      const accountNick = user ? user.nc : nick
+      // Group the new alias under the account's display nick. `user.nc` comes from the
+      // NickCore→NickAlias left join and is null when the account has no aliases yet,
+      // which would create an orphaned alias (nc = NULL); the display is always the group key.
+      const accountNick = user ? (user.display ?? user.nc) : nick
 
       const insertedNickname = await transaction.insert({
         nc: accountNick,

--- a/src/routes/Nicknames.mjs
+++ b/src/routes/Nicknames.mjs
@@ -115,7 +115,13 @@ export default class Nickname extends APIResource {
 
     const existingNick = await Anope.findNickname(nick)
     if (existingNick) {
-      throw new ConflictAPIError({ pointer: '/data/attributes/nick' })
+      // A dangling alias with no backing account (email is null) is not a real
+      // registration — it can't be listed or resolved via whois. Rather than block the
+      // nick forever, clear the stale row (by its exact id) and continue registering.
+      if (existingNick.email) {
+        throw new ConflictAPIError({ pointer: '/data/attributes/nick' })
+      }
+      await Anope.removeNicknameByAnopeId(existingNick.anopeId)
     }
 
     const encryptedPassword = `bcrypt:${targetUser.password}`


### PR DESCRIPTION
Promotes `develop` → `main` (prod deploy of `fr-api_api`).

Contains only #729 — `fix(nicknames): prevent and heal orphaned Anope nick aliases`:
- stop `addNewUser` creating `nc=NULL` orphan aliases (group under account `display`)
- prune emptied `NickCore` on last-alias removal
- `findNickname` prefers the account-backed row over a co-named orphan
- `POST /nicknames` clears a dangling account-less alias by id instead of a permanent 409

No schema changes. Fixes the CMDR `arckoor` class of "409 on add, but web/whois show no nick."